### PR TITLE
add peptide-DNA/RNA link

### DIFF
--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -41958,6 +41958,17 @@ DEL-OXT delete plan-1 CA 0.020
 DEL-OXT delete plan-1 O 0.020
 DEL-OXT delete plan-1 OXT 0.020
 
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-OXT delete O C CA N 0.000 10.0
+
 data_mod_DEL-OXT1
 loop_
 _chem_mod_atom.mod_id

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -36004,6 +36004,7 @@ VAL-SUI . DEL-OXT peptide SUI SUImod1 NON-POLYMER VAL-SUI
 SUI-GLN SUI DEL-OXT NON-POLYMER . DEL-HN1 peptide SUI-GLN
 gap . . . . . . gap-link
 p . DEL_HO3p DNA/RNA . DEL_OP3 DNA/RNA default-DNA/RNA-link
+AA-RNA . DEL-OXT peptide . DEL_HO3p DNA/RNA aminoacyl-RNA
 RNA-F86 . DEL_HO3p DNA/RNA F86 F86m1 NON-POLYMER RNA-F86
 FOR_C-N FOR . NON-POLYMER . . peptide bond_FOR-C_=_N-peptide
 FOR_C-C . . peptide FOR . NON-POLYMER bond_FOR-C_=_C-peptide
@@ -36927,6 +36928,60 @@ _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
 p 2 P 2 "O5'" 1 "O3'" 2 OP2 both
+
+data_link_AA-RNA
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+AA-RNA     1         C         2         "O3'"     SINGLE    1.278       0.0200
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+AA-RNA     1         CA        1         C         2         "O3'"     120.000        3.00
+AA-RNA     1         O         1         C         2         "O3'"     120.000        3.00
+AA-RNA     2         "C3'"     2         "O3'"     1         C         120.000        3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+AA-RNA     sp2_sp2_1       1         CA        1         C         2         "O3'"     2         "C3'"     180.000        5.0       2
+AA-RNA     sp3_sp3_1       2         "C4'"     2         "C3'"     2         "O3'"     1         C         180.000        10.0      3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+AA-RNA     plan-1    1         CA        0.020
+AA-RNA     plan-1    1         C         0.020
+AA-RNA     plan-1    2         "O3'"     0.020
+AA-RNA     plan-1    1         O         0.020
 
 data_link_RNA-F86
 loop_

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -36939,7 +36939,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-AA-RNA     1         C         2         "O3'"     SINGLE    1.278       0.0200
+AA-RNA     1         C         2         "O3'"     SINGLE    1.334       0.0128
 
 loop_
 _chem_link_angle.link_id
@@ -36951,9 +36951,9 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-AA-RNA     1         CA        1         C         2         "O3'"     120.000        3.00
-AA-RNA     1         O         1         C         2         "O3'"     120.000        3.00
-AA-RNA     2         "C3'"     2         "O3'"     1         C         120.000        3.00
+AA-RNA     1         CA        1         C         2         "O3'"     111.770        3.00
+AA-RNA     1         O         1         C         2         "O3'"     123.273        1.50
+AA-RNA     2         "C3'"     2         "O3'"     1         C         116.978        1.50
 
 loop_
 _chem_link_tor.link_id


### PR DESCRIPTION
I created a link using Acedrg 256 with the following instruction
```
LINK: RES-NAME-1 ALA ATOM-NAME-1 C RES-NAME-2 A ATOM-NAME-2  O3' DELETE ATOM OXT 1
```
and replaced modifications with DEL-OXT and DEL_HO3p.

Some high resolution examples from PDB:
| PDB | resolution | source | atoms |
| -- | -- | -- | -- |
| 1vq8 | 2.2 A | X-ray | 4/PHE 77/C - 4/DA 76/O3' |
| 7o7y | 2.2 A | EM | BK/PHE 4399/C - AT/A 76/O3' |
| 7qi4 | 2.21 A | EM  | B/VAL 101/C - B/A 76/O3' |