### PR TITLE
fix FES and add FES-CYS links

### DIFF
--- a/f/FES.cif
+++ b/f/FES.cif
@@ -45,10 +45,10 @@ _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-FES FE1 S1 single 2.235 0.020 2.235 0.020
-FES FE1 S2 single 2.235 0.020 2.235 0.020
-FES FE2 S1 single 2.235 0.020 2.235 0.020
-FES S2 FE2 single 2.235 0.020 2.235 0.020
+FES FE1 S1 single 2.20 0.020 2.20 0.020
+FES FE1 S2 single 2.20 0.020 2.20 0.020
+FES FE2 S1 single 2.20 0.020 2.20 0.020
+FES S2 FE2 single 2.20 0.020 2.20 0.020
 
 loop_
 _chem_comp_angle.comp_id
@@ -57,32 +57,8 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-FES FE2 S1 FE1 88.422 3.000
-FES S1 FE2 S2 90.000 3.000
-FES FE2 S2 FE1 88.422 3.000
-FES S2 FE1 S1 90.000 3.000
+FES FE2 S1  FE1 73.700 3.00
+FES S1  FE2 S2  104.10 3.00
+FES FE2 S2  FE1 73.700 3.00
+FES S2  FE1 S1  104.10 3.00
 
-loop_
-_chem_comp_tor.comp_id
-_chem_comp_tor.id
-_chem_comp_tor.atom_id_1
-_chem_comp_tor.atom_id_2
-_chem_comp_tor.atom_id_3
-_chem_comp_tor.atom_id_4
-_chem_comp_tor.value_angle
-_chem_comp_tor.value_angle_esd
-_chem_comp_tor.period
-FES var_1 FE1 S2 FE2 S1 0.000 20.000 1
-FES var_2 FE2 S2 FE1 S1 0.000 20.000 1
-FES var_3 FE2 S1 FE1 S2 0.000 20.000 1
-
-loop_
-_chem_comp_chir.comp_id
-_chem_comp_chir.id
-_chem_comp_chir.atom_id_centre
-_chem_comp_chir.atom_id_1
-_chem_comp_chir.atom_id_2
-_chem_comp_chir.atom_id_3
-_chem_comp_chir.volume_sign
-FES chir_01 FE1 S2 . S1 cross1
-FES chir_02 FE2 S1 . S2 cross1

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -36035,6 +36035,8 @@ HEC-CYS2 HEC HECmod2 NON-POLYMER CYS CYSmod1 peptide HEC_CAB-CYS2
 FE-CYS FE . NON-POLYMER CYS CYSmod1 peptide bond_FE_=_CYS-SG
 FE-HISND FE . NON-POLYMER HIS DEL-HD1 peptide bond_FE_=_HIS-ND1
 FE-HISNE FE . NON-POLYMER HIS DEL-HE2 peptide bond_FE_=_HIS-NE2
+FES1-CYS FES . NON-POLYMER CYS CYSmod1 peptide bond_FES1_CYS-SG
+FES2-CYS FES . NON-POLYMER CYS CYSmod1 peptide bond_FES2_CYS-SG
 SF41-CYS SF4 . NON-POLYMER CYS CYSmod1 peptide bond_SF41_CYS-SG
 SF42-CYS SF4 . NON-POLYMER CYS CYSmod1 peptide bond_SF42_CYS-SG
 SF43-CYS SF4 . NON-POLYMER CYS CYSmod1 peptide bond_SF43_CYS-SG
@@ -38180,6 +38182,58 @@ _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
 FE-HISNE 1 FE 2 NE2 2 CD2 125.500 3.000
 FE-HISNE 1 FE 2 NE2 2 CE1 125.500 3.000
+
+data_link_FES1-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+FES1-CYS 1 FE1 2 SG single 2.280 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+FES1-CYS 1 FE1 2 SG 2 CB 105.8 3.00
+FES1-CYS 1 S1 1 FE1 2 SG 111.0 3.00
+FES1-CYS 1 S2 1 FE1 2 SG 111.0 3.00
+
+data_link_FES2-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+FES2-CYS 1 FE2 2 SG single 2.280 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+FES2-CYS 1 FE2 2 SG 2 CB 105.8 3.00
+FES2-CYS 1 S1 1 FE2 2 SG 111.0 3.00
+FES2-CYS 1 S2 1 FE2 2 SG 111.0 3.00
 
 data_link_SF41-CYS
 loop_


### PR DESCRIPTION
- FES monomer corrected (took angles from SF4 and distances from COD analysis)
- FES-CYS links added (distances and S-Fe-S angle from COD analysis; Fe-S-C angle from PDB analysis)

We may want to add bimodality for angle restraints, but for now single target angles are used.