### PR TITLE
fix zeta/epsilon torsion of p link

### DIFF
--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -36913,7 +36913,7 @@ _chem_link_tor.atom_id_4
 _chem_link_tor.value_angle
 _chem_link_tor.value_angle_esd
 _chem_link_tor.period
-p zeta 1 "C3'" 1 "O3'" 2 P 2 O5' 60.000 10.00 3
+p zeta 1 "C3'" 1 "O3'" 2 P 2 "O5'" 60.000 10.00 3
 p epsilon 1 "C4'" 1 "C3'" 1 "O3'" 2 P 180.000 10.00 3
 
 loop_

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -36913,8 +36913,8 @@ _chem_link_tor.atom_id_4
 _chem_link_tor.value_angle
 _chem_link_tor.value_angle_esd
 _chem_link_tor.period
-p zeta 1 "C3'" 1 "O3'" 2 P 2 OP1 60.000 10.00 3
-p epsilon 1 "C4'" 1 "C3'" 1 "O3'" 1 P 180.000 10.00 3
+p zeta 1 "C3'" 1 "O3'" 2 P 2 O5' 60.000 10.00 3
+p epsilon 1 "C4'" 1 "C3'" 1 "O3'" 2 P 180.000 10.00 3
 
 loop_
 _chem_link_chir.link_id


### PR DESCRIPTION
@wojdyr found the epsilon torsion angle of the p link (DNA/RNA link) takes wrong P atom. I also corrected zeta torsion angle just to follow the standard definition of zeta.