### PR TITLE
fix data_mod_list

### DIFF
--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -36116,7 +36116,6 @@ CYSmod1 CYS-HG-delete_with_atom_type CYS peptide
 NH3 NH3-terminus . peptide
 NH1 NH1-terminus . peptide
 NH2 NH2-terminus_for_proline . peptide
-NHmod NHmod-terminus_for_link . peptide
 ACEmod ACEmod-for_ACE_PEP_link ACE NON-POLYMER
 NH2N NH2-terminus_proline_type_with_CN . peptide
 COO COO-terminus . peptide


### PR DESCRIPTION
data_mod_NHmod was removed in #10, but NHmod remained in data_mod_list.

It causes a problem with gemmi 0.5.7 https://github.com/project-gemmi/gemmi/blob/6830e4c1e80ae6cf2a48366ced2c0d196dd18f23/include/gemmi/monlib.hpp#L346 The latest gemmi is ok with it (since https://github.com/project-gemmi/gemmi/commit/b30542e5)