### PR TITLE
fix insufficient restraints to define hydrogen geometry

### DIFF
--- a/b/BFD.cif
+++ b/b/BFD.cif
@@ -1,11 +1,3 @@
-global_
-_lib_name         ?
-_lib_version      ?
-_lib_update       ?
-# ------------------------------------------------
-#
-# ---   LIST OF MONOMERS ---
-#
 data_comp_list
 loop_
 _chem_comp.id
@@ -15,91 +7,67 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-BFD      BFD 'ASPARTATE BERYLLIUM TRIFLUORIDE     ' peptide            18  13 .
-# ------------------------------------------------------
-# ------------------------------------------------------
-#
-# --- DESCRIPTION OF MONOMERS ---
-#
+BFD BFD "ASPARTATE BERYLLIUM TRIFLUORIDE" peptide 19 13 .
+
 data_comp_BFD
-#
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
-_chem_comp_atom.partial_charge
+_chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
- BFD           N      N    NH2       0.000      0.000    0.000    0.000
- BFD           HN1    H    H         0.000     -0.161    0.991    0.093
- BFD           HN2    H    H         0.000      0.031   -0.426   -0.914
- BFD           CA     C    CH1       0.000      0.186   -0.812    1.178
- BFD           HA     H    H         0.000     -0.641   -1.526    1.293
- BFD           CB     C    CH2       0.000      1.533   -1.549    1.063
- BFD           HB2    H    H         0.000      2.274   -0.834    0.699
- BFD           HB3    H    H         0.000      1.413   -2.350    0.330
- BFD           CG     C    C         0.000      1.999   -2.136    2.386
- BFD           OD2    O    O        -0.500      3.103   -1.724    2.807
- BFD           OD1    O    O2       -0.500      1.227   -2.932    2.967
- BFD           BE     BE   BE       -2.000      1.293   -3.519    4.386
- BFD           F1     F    F         0.000      0.839   -4.956    4.291
- BFD           F2     F    F         0.000      2.677   -3.516    5.000
- BFD           F3     F    F         0.000      0.346   -2.727    5.274
- BFD           C      C    C         0.000      0.201    0.220    2.362
- BFD           O      O    OC       -0.500      0.449    1.432    2.181
- BFD           OXT    O    OC       -0.500     -0.062   -0.227    3.500
-loop_
-_chem_comp_tree.comp_id
-_chem_comp_tree.atom_id
-_chem_comp_tree.atom_back
-_chem_comp_tree.atom_forward
-_chem_comp_tree.connect_type
- BFD      N      n/a    CA     START
- BFD      HN1    N      .      .
- BFD      HN2    N      .      .
- BFD      CA     N      C      .
- BFD      HA     CA     .      .
- BFD      CB     CA     CG     .
- BFD      HB2    CB     .      .
- BFD      HB3    CB     .      .
- BFD      CG     CB     OD1    .
- BFD      OD2    CG     .      .
- BFD      OD1    CG     BE     .
- BFD      BE     OD1    F3     .
- BFD      F1     BE     .      .
- BFD      F2     BE     .      .
- BFD      F3     BE     .      .
- BFD      C      CA     .      END
- BFD      O      C      .      .
- BFD      OXT    C      .      .
+BFD N   N  NT3 1  60.652 15.977 43.565
+BFD CA  C  CH1 0  60.384 15.714 45.010
+BFD C   C  C   0  59.450 16.803 45.560
+BFD O   O  O   0  59.770 17.998 45.354
+BFD CB  C  CH2 0  61.672 15.599 45.817
+BFD CG  C  C   0  61.515 15.061 47.213
+BFD OD1 O  O   0  61.333 13.738 47.226
+BFD OD2 O  O   0  61.548 15.733 48.213
+BFD OXT O  OC  -1 58.430 16.420 46.176
+BFD BE  BE BE  -2 59.994 13.096 47.898
+BFD F1  F  F   0  60.043 11.562 47.775
+BFD F2  F  F   0  59.926 13.490 49.385
+BFD F3  F  F   0  58.747 13.629 47.167
+BFD H   H  H   0  61.127 16.737 43.454
+BFD H2  H  H   0  59.872 16.064 43.120
+BFD H3  H  H   0  61.106 15.291 43.195
+BFD HA  H  H   0  59.922 14.847 45.078
+BFD HB2 H  H   0  62.081 16.487 45.868
+BFD HB3 H  H   0  62.289 15.017 45.326
+
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
 _chem_comp_bond.type
+_chem_comp_bond.aromatic
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-BFD       CA        N         single    1.450     0.020     1.450     0.020     
-BFD       C         CA        single    1.500     0.020     1.500     0.020     
-BFD       CB        CA        single    1.524     0.020     1.524     0.020     
-BFD       HA        CA        single    1.089     0.010     0.989     0.005     
-BFD       O         C         deloc     1.250     0.020     1.250     0.020     
-BFD       OXT       C         deloc     1.250     0.020     1.250     0.020     
-BFD       CG        CB        single    1.510     0.020     1.510     0.020     
-BFD       HB2       CB        single    1.089     0.010     0.989     0.005     
-BFD       HB3       CB        single    1.089     0.010     0.989     0.005     
-BFD       OD1       CG        deloc     1.454     0.020     1.454     0.020     
-BFD       OD2       CG        deloc     1.220     0.020     1.220     0.020     
-BFD       BE        OD1       single    1.750     0.020     1.750     0.020     
-BFD       F1        BE        single    1.765     0.020     1.765     0.020     
-BFD       F2        BE        single    1.765     0.020     1.765     0.020     
-BFD       F3        BE        single    1.765     0.020     1.765     0.020     
-BFD       HN1       N         single    1.036     0.016     0.914     0.007     
-BFD       HN2       N         single    1.036     0.016     0.914     0.007     
+BFD N   CA  SINGLE n 1.490 0.0100 1.490 0.0100
+BFD CA  C   SINGLE n 1.533 0.0100 1.533 0.0100
+BFD CA  CB  SINGLE n 1.521 0.0100 1.521 0.0100
+BFD C   O   DOUBLE n 1.251 0.0183 1.251 0.0183
+BFD C   OXT SINGLE n 1.251 0.0183 1.251 0.0183
+BFD CB  CG  SINGLE n 1.502 0.0144 1.502 0.0144
+BFD CG  OD1 SINGLE n 1.333 0.0200 1.333 0.0200
+BFD CG  OD2 DOUBLE n 1.205 0.0181 1.205 0.0181
+BFD OD1 BE  SINGLE n 1.630 0.0250 1.630 0.0250
+BFD BE  F1  SINGLE n 1.540 0.0199 1.540 0.0199
+BFD BE  F2  SINGLE n 1.540 0.0199 1.540 0.0199
+BFD BE  F3  SINGLE n 1.540 0.0199 1.540 0.0199
+BFD N   H   SINGLE n 1.036 0.0160 0.902 0.0102
+BFD N   H2  SINGLE n 1.036 0.0160 0.902 0.0102
+BFD N   H3  SINGLE n 1.036 0.0160 0.902 0.0102
+BFD CA  HA  SINGLE n 1.089 0.0100 0.984 0.0200
+BFD CB  HB2 SINGLE n 1.089 0.0100 0.980 0.0165
+BFD CB  HB3 SINGLE n 1.089 0.0100 0.980 0.0165
+
 loop_
 _chem_comp_angle.comp_id
 _chem_comp_angle.atom_id_1
@@ -107,34 +75,38 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
- BFD      HN1    N      HN2     120.000    3.000
- BFD      HN1    N      CA      120.000    3.000
- BFD      HN2    N      CA      120.000    3.000
- BFD      N      CA     HA      109.470    3.000
- BFD      N      CA     CB      109.470    3.000
- BFD      N      CA     C       109.470    3.000
- BFD      HA     CA     CB      108.340    3.000
- BFD      HA     CA     C       108.810    3.000
- BFD      CB     CA     C       109.470    3.000
- BFD      CA     CB     HB2     109.470    3.000
- BFD      CA     CB     HB3     109.470    3.000
- BFD      CA     CB     CG      109.470    3.000
- BFD      HB2    CB     HB3     107.900    3.000
- BFD      HB2    CB     CG      109.470    3.000
- BFD      HB3    CB     CG      109.470    3.000
- BFD      CB     CG     OD2     120.500    3.000
- BFD      CB     CG     OD1     120.000    3.000
- BFD      OD2    CG     OD1     119.000    3.000
- BFD      CG     OD1    BE      120.000    3.000
- BFD      OD1    BE     F1      120.000    3.000
- BFD      OD1    BE     F2      120.000    3.000
- BFD      OD1    BE     F3      120.000    3.000
- BFD      F1     BE     F2      120.000    3.000
- BFD      F1     BE     F3      120.000    3.000
- BFD      F2     BE     F3      120.000    3.000
- BFD      CA     C      O       118.500    3.000
- BFD      CA     C      OXT     118.500    3.000
- BFD      O      C      OXT     123.000    3.000
+BFD CA  N   H   109.990 3.00
+BFD CA  N   H2  109.990 3.00
+BFD CA  N   H3  109.990 3.00
+BFD H   N   H2  109.032 3.00
+BFD H   N   H3  109.032 3.00
+BFD H2  N   H3  109.032 3.00
+BFD N   CA  C   109.258 1.50
+BFD N   CA  CB  111.400 1.50
+BFD N   CA  HA  108.387 1.58
+BFD C   CA  CB  112.421 3.00
+BFD C   CA  HA  108.774 1.79
+BFD CB  CA  HA  108.472 2.65
+BFD CA  C   O   117.148 1.60
+BFD CA  C   OXT 117.148 1.60
+BFD O   C   OXT 125.704 1.50
+BFD CA  CB  CG  113.683 3.00
+BFD CA  CB  HB2 108.799 3.00
+BFD CA  CB  HB3 108.799 3.00
+BFD CG  CB  HB2 108.759 1.50
+BFD CG  CB  HB3 108.759 1.50
+BFD HB2 CB  HB3 107.976 2.66
+BFD CB  CG  OD1 111.572 3.00
+BFD CB  CG  OD2 124.713 1.50
+BFD OD1 CG  OD2 123.715 3.00
+BFD CG  OD1 BE  120.000 3.00
+BFD OD1 BE  F1  109.471 1.94
+BFD OD1 BE  F2  109.471 1.94
+BFD OD1 BE  F3  109.471 1.94
+BFD F1  BE  F2  109.471 1.94
+BFD F1  BE  F3  109.471 1.94
+BFD F2  BE  F3  109.471 1.94
+
 loop_
 _chem_comp_tor.comp_id
 _chem_comp_tor.id
@@ -145,11 +117,13 @@ _chem_comp_tor.atom_id_4
 _chem_comp_tor.value_angle
 _chem_comp_tor.value_angle_esd
 _chem_comp_tor.period
- BFD      var_1    HN2    N      CA     C        175.000   20.000   1
- BFD      var_2    N      CA     CB     CG       164.870   20.000   3
- BFD      var_3    CA     CB     CG     OD1       56.806   20.000   3
- BFD      var_4    CB     CG     OD1    BE      -169.466   20.000   1
- BFD      var_5    CG     OD1    BE     F3        99.650   20.000   1
+BFD chi1        N  CA CB  CG  180.000 10.0 3
+BFD chi2        CA CB CG  OD1 60.000  10.0 6
+BFD sp3_sp3_1   C  CA N   H   180.000 10.0 3
+BFD sp3_sp3_19  F1 BE OD1 CG  180.000 10.0 3
+BFD other_tor_1 CB CG OD1 BE  180.000 10.0 2
+BFD sp2_sp3_1   O  C  CA  N   0.000   10.0 6
+
 loop_
 _chem_comp_chir.comp_id
 _chem_comp_chir.id
@@ -158,23 +132,43 @@ _chem_comp_chir.atom_id_1
 _chem_comp_chir.atom_id_2
 _chem_comp_chir.atom_id_3
 _chem_comp_chir.volume_sign
- BFD      chir_01  CA     N      C      CB        positiv
- BFD      chir_02  BE     OD1    F1     F2        both
+BFD chir_1 CA N  C  CB positive
+BFD chir_2 BE F1 F2 F3 both
+
 loop_
 _chem_comp_plane_atom.comp_id
 _chem_comp_plane_atom.plane_id
 _chem_comp_plane_atom.atom_id
 _chem_comp_plane_atom.dist_esd
- BFD      plan-1    N         0.020
- BFD      plan-1    CA        0.020
- BFD      plan-1    HN1       0.020
- BFD      plan-1    HN2       0.020
- BFD      plan-2    C         0.020
- BFD      plan-2    CA        0.020
- BFD      plan-2    O         0.020
- BFD      plan-2    OXT       0.020
- BFD      plan-3    CG        0.020
- BFD      plan-3    CB        0.020
- BFD      plan-3    OD1       0.020
- BFD      plan-3    OD2       0.020
-# ------------------------------------------------------
+BFD plan-1 C   0.020
+BFD plan-1 CA  0.020
+BFD plan-1 O   0.020
+BFD plan-1 OXT 0.020
+BFD plan-2 CB  0.020
+BFD plan-2 CG  0.020
+BFD plan-2 OD1 0.020
+BFD plan-2 OD2 0.020
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+BFD SMILES           ACDLabs              10.04 "O=C(O[Be-2](F)(F)F)CC(N)C(=O)O"
+BFD SMILES_CANONICAL CACTVS               3.341 "N[C@@H](CC(=O)O[Be--](F)(F)F)C(O)=O"
+BFD SMILES           CACTVS               3.341 "N[CH](CC(=O)O[Be--](F)(F)F)C(O)=O"
+BFD SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0 "[Be-2](OC(=O)C[C@@H](C(=O)O)N)(F)(F)F"
+BFD SMILES           "OpenEye OEToolkits" 1.5.0 "[Be-2](OC(=O)CC(C(=O)O)N)(F)(F)F"
+BFD InChI            InChI                1.03  "InChI=1S/C4H7NO4.Be.3FH/c5-2(4(8)9)1-3(6)7;;;;/h2H,1,5H2,(H,6,7)(H,8,9);;3*1H/q;+2;;;/p-4/t2-;;;;/m0..../s1"
+BFD InChIKey         InChI                1.03  AHUXVQYBCVIJSZ-AIDJSRAFSA-J
+
+loop_
+_pdbx_chem_comp_description_generator.comp_id
+_pdbx_chem_comp_description_generator.program_name
+_pdbx_chem_comp_description_generator.program_version
+_pdbx_chem_comp_description_generator.descriptor
+BFD acedrg          269       "dictionary generator"
+BFD acedrg_database 12        "data source"
+BFD rdkit           2019.09.1 "Chemoinformatics tool"
+BFD servalcat       0.3.9     'optimization tool'

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -36005,7 +36005,7 @@ _chem_link.name
 DG9-SER DG9 DG9m1 NON-POLYMER SER SERm1 peptide DG9-SER
 SS . CYS-SS peptide . CYS-SS peptide SS-bridge
 disulf CYS CYS-SS peptide CYS CYS-SS peptide SS-bridge
-CYS-MPR CYS CYS-SS peptide MPR . NON-POLYMER SS-bridge
+CYS-MPR CYS CYS-SS peptide MPR MPRm1 NON-POLYMER SS-bridge
 TRANS . DEL-OXT peptide . DEL-HN1 peptide TRANS
 CIS . DEL-OXT peptide . DEL-HN1 peptide CIS
 PTRANS . DEL-OXT peptide . DEL-HNP P-peptide PTRANS
@@ -36018,14 +36018,14 @@ gap . . . . . . gap-link
 p . DEL_HO3p DNA/RNA . DEL_OP3 DNA/RNA default-DNA/RNA-link
 AA-RNA . DEL-OXT peptide . DEL_HO3p DNA/RNA aminoacyl-RNA
 RNA-F86 . DEL_HO3p DNA/RNA F86 F86m1 NON-POLYMER RNA-F86
-FOR_C-N FOR . NON-POLYMER . . peptide bond_FOR-C_=_N-peptide
+FOR_C-N FOR FORm1 NON-POLYMER . DEL-HN1 peptide bond_FOR-C_=_N-peptide
 FOR_C-C . . peptide FOR . NON-POLYMER bond_FOR-C_=_C-peptide
 FOR-LYZ LYZ . peptide FOR . NON-POLYMER bond_FOR-C_=_NZ-LYZ
 ACE_C-N ACE ACEmod NON-POLYMER . DEL-HN1 peptide bond_ACE-C_=_N_peptide
 AHT-ALA AHT . NON-POLYMER ALA . peptide bond_AHT-N2_=_CB-ALA
-IVA_C-N IVA . NON-POLYMER . . peptide bond_IVA-C_=_N-peptide
-BOC_C-N BOC . NON-POLYMER . . peptide bond_BOC-C_=_N-peptide
-NME_N-C . . peptide NME . NON-POLYMER bond_NME-N_=_C-peptide
+IVA_C-N IVA IVAm1 NON-POLYMER . DEL-HN1 peptide bond_IVA-C_=_N-peptide
+BOC_C-N BOC BOCm1 NON-POLYMER . DEL-HN1 peptide bond_BOC-C_=_N-peptide
+NME_N-C . DEL-OXT peptide NME NMEm1 NON-POLYMER bond_NME-N_=_C-peptide
 ALPHA1-2 . DEL-HO2 pyranose . DEL-O1 pyranose glycosidic_bond_alpha1-2
 ALPHA1-3 . DEL-HO3 pyranose . DEL-O1 pyranose glycosidic_bond_alpha1-3
 ALPHA2-3 . DEL-O2 ketopyranose . DEL-HO3 pyranose glycosidic_bond_alpha2-3
@@ -36057,8 +36057,8 @@ SF31-CYS SF3 . NON-POLYMER CYS CYSmod1 peptide bond_SF31_CYS-SG
 SF32-CYS SF3 . NON-POLYMER CYS CYSmod1 peptide bond_SF32_CYS-SG
 SF33-CYS SF3 . NON-POLYMER CYS CYSmod1 peptide bond_SF33_CYS-SG
 SF34-CYS SF3 . NON-POLYMER CYS CYSmod1 peptide bond_SF34_CYS-SG
-ACYSNN ACY ACYmod NON-POLYMER SNN SNNmod NON-POLYMER 'ACYSNN'
-ALASNN . ALAmod peptide SNN SNNmod NON-POLYMER 'ALASNN'
+ACYSNN ACY ACYmod NON-POLYMER SNN SNNmod1 NON-POLYMER 'ACYSNN'
+pept-SNN . DEL-OXT peptide SNN SNNmod NON-POLYMER 'pept-SNN'
 TPN-TPN TPN TPNmodC NON-POLYMER TPN TPNmodN NON-POLYMER TPN-TPN
 PEP-ORN . DEL-OXT peptide ORN ORN-NE peptide PEP-ORN
 symmetry . . . . . . dummy_link
@@ -36113,6 +36113,8 @@ DG9m1 DG9 DG9 NON-POLYMER
 SERm1 SERINE SER peptide
 CYS-SS HG-deletete CYS peptide
 CYSmod1 CYS-HG-delete_with_atom_type CYS peptide
+MPRm1 MPR-HS3-delete_with_atom_type MPR NON-POLYMER
+FORm1 FOR-H2-delete FOR NON-POLYMER
 NH3 NH3-terminus . peptide
 NH1 NH1-terminus . peptide
 NH2 NH2-terminus_for_proline . peptide
@@ -36169,9 +36171,11 @@ DEL-HD22 delete_HD22_from_ASN ASN peptide
 DEL-HG delete_HG_from_SER SER peptide
 DEL-HG1 delete_HG1_from_THR THR peptide
 ACYmod 'ACYmod' ACY NON-POLYMER
+IVAm1 'IVA_delOXT' IVA NON-POLYMER
+BOCm1 'BOC_delO3' BOC NON-POLYMER
+NMEm1 'NME_delH' NME NON-POLYMER
 SNNmod 'SNNmod' SNN NON-POLYMER
-ALAmod 'ALAmod' . peptide
-SNNmd1 'SNNmod' SNN NON-POLYMER
+SNNmod1 'SNNmod' SNN NON-POLYMER
 TPNmodC 2-AMINOETHYLGLYCINE-CARBONYLMETHYLEN TPN NON-POLYMER
 TPNmodN 2-AMINOETHYLGLYCINE-CARBONYLMETHYLEN TPN NON-POLYMER
 ORN-NE 'ORNITHINE                           ' ORN peptide
@@ -36376,7 +36380,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-CYS-MPR 1 SG 2 S3 single 2.031 .020
+CYS-MPR 1 SG 2 S3 SINGLE 2.032 0.0100
 
 loop_
 _chem_link_angle.link_id
@@ -36388,8 +36392,8 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-CYS-MPR 1 CB 1 SG 2 S3 110.000 3.000
-CYS-MPR 1 SG 2 S3 2 CB 110.000 3.000
+CYS-MPR 1 CB 1 SG 2 S3 103.477 2.39
+CYS-MPR 2 C3 2 S3 1 SG 103.834 1.50
 
 loop_
 _chem_link_tor.link_id
@@ -36405,7 +36409,9 @@ _chem_link_tor.atom_id_4
 _chem_link_tor.value_angle
 _chem_link_tor.value_angle_esd
 _chem_link_tor.period
-CYS-MPR ss 1 CB 1 SG 2 S3 2 CB 90.00 10.0 2
+CYS-MPR sp3_sp3_1 2 C3 2 S3 1 SG 1 CB 180.000 10.0 3
+CYS-MPR sp3_sp3_2 2 C2 2 C3 2 S3 1 SG 180.000 10.0 3
+CYS-MPR sp3_sp3_3 1 CA 1 CB 1 SG 2 S3 180.000 10.0 3
 
 data_link_TRANS
 loop_
@@ -37062,7 +37068,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-FOR_C-N 1 C 2 N single 1.329 .020
+FOR_C-N 1 C 2 N SINGLE 1.329 0.0194
 
 loop_
 _chem_link_angle.link_id
@@ -37074,8 +37080,10 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-FOR_C-N 1 C 2 N 2 CA 121.700 3.000
-FOR_C-N 1 O 1 C 2 N 123.000 3.000
+FOR_C-N 1 O 1 C 2 N 125.587 1.50
+FOR_C-N 2 N 1 C 1 H1 116.011 3.00
+FOR_C-N 2 CA 2 N 1 C 122.076 3.00
+FOR_C-N 1 C 2 N 2 H 118.750 3.00
 
 loop_
 _chem_link_tor.link_id
@@ -37091,7 +37099,23 @@ _chem_link_tor.atom_id_4
 _chem_link_tor.value_angle
 _chem_link_tor.value_angle_esd
 _chem_link_tor.period
-FOR_C-N var1 1 O 1 C 2 N 2 CA .00 30.0 2
+FOR_C-N sp2_sp2_1 1 O 1 C 2 N 2 CA 180.000 5.0 2
+FOR_C-N sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+FOR_C-N plan-1 1 C 0.020
+FOR_C-N plan-1 1 H1 0.020
+FOR_C-N plan-1 2 N 0.020
+FOR_C-N plan-1 1 O 0.020
+FOR_C-N plan-2 1 C 0.020
+FOR_C-N plan-2 2 CA 0.020
+FOR_C-N plan-2 2 H 0.020
+FOR_C-N plan-2 2 N 0.020
 
 data_link_FOR_C-C
 loop_
@@ -37256,7 +37280,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-IVA_C-N 1 C 2 N single 1.340 .020
+IVA_C-N 1 C 2 N SINGLE 1.343 0.0101
 
 loop_
 _chem_link_angle.link_id
@@ -37268,8 +37292,42 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-IVA_C-N 1 O 1 C 2 N 129.100 3.000
-IVA_C-N 1 C 2 N 2 CA 119.300 3.000
+IVA_C-N 1 CA 1 C 2 N 115.437 3.00
+IVA_C-N 1 O 1 C 2 N 122.517 1.50
+IVA_C-N 2 CA 2 N 1 C 122.000 2.97
+IVA_C-N 1 C 2 N 2 H 118.959 1.65
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+IVA_C-N sp2_sp2_1 1 CA 1 C 2 N 2 CA 180.000 5.0 2
+IVA_C-N sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+IVA_C-N plan-1 1 CA 0.020
+IVA_C-N plan-1 1 C 0.020
+IVA_C-N plan-1 2 N 0.020
+IVA_C-N plan-1 1 O 0.020
+IVA_C-N plan-2 2 CA 0.020
+IVA_C-N plan-2 1 C 0.020
+IVA_C-N plan-2 2 H 0.020
+IVA_C-N plan-2 2 N 0.020
 
 data_link_BOC_C-N
 loop_
@@ -37281,7 +37339,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-BOC_C-N 1 C 2 N single 1.340 .020
+BOC_C-N 1 C 2 N SINGLE 1.345 0.0115
 
 loop_
 _chem_link_angle.link_id
@@ -37293,8 +37351,42 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-BOC_C-N 1 O1 1 C 2 N 129.100 3.000
-BOC_C-N 1 C 2 N 2 CA 119.300 3.000
+BOC_C-N 1 O1 1 C 2 N 124.509 1.50
+BOC_C-N 1 O2 1 C 2 N 109.945 1.50
+BOC_C-N 2 CA 2 N 1 C 121.285 3.00
+BOC_C-N 1 C 2 N 2 H 119.271 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BOC_C-N sp2_sp2_1 1 O1 1 C 2 N 2 CA 0.000 5.0 2
+BOC_C-N sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+BOC_C-N plan-1 1 C 0.020
+BOC_C-N plan-1 2 N 0.020
+BOC_C-N plan-1 1 O1 0.020
+BOC_C-N plan-1 1 O2 0.020
+BOC_C-N plan-2 2 CA 0.020
+BOC_C-N plan-2 1 C 0.020
+BOC_C-N plan-2 2 H 0.020
+BOC_C-N plan-2 2 N 0.020
 
 data_link_NME_N-C
 loop_
@@ -37306,7 +37398,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-NME_N-C 1 C 2 N single 1.308 .020
+NME_N-C 1 C 2 N SINGLE 1.330 0.0147
 
 loop_
 _chem_link_angle.link_id
@@ -37318,8 +37410,41 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-NME_N-C 1 O 1 C 2 N 126.200 3.000
-NME_N-C 1 C 2 N 2 CH3 123.400 3.000
+NME_N-C 1 CA 1 C 2 N 115.984 1.50
+NME_N-C 1 O 1 C 2 N 123.444 1.50
+NME_N-C 2 C 2 N 1 C 122.082 1.50
+NME_N-C 1 C 2 N 2 HN1 119.088 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+NME_N-C sp2_sp2_1 1 CA 1 C 2 N 2 C 180.000 5.0 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+NME_N-C plan-1 1 CA 0.020
+NME_N-C plan-1 1 C 0.020
+NME_N-C plan-1 2 N 0.020
+NME_N-C plan-1 1 O 0.020
+NME_N-C plan-2 2 C 0.020
+NME_N-C plan-2 1 C 0.020
+NME_N-C plan-2 2 HN1 0.020
+NME_N-C plan-2 2 N 0.020
 
 data_link_ALPHA1-2
 loop_
@@ -38448,7 +38573,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-ACYSNN 1 CH3 2 N1 single 1.455 0.020
+ACYSNN 1 CH3 2 N1 SINGLE 1.456 0.0102
 
 loop_
 _chem_link_angle.link_id
@@ -38460,11 +38585,29 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-ACYSNN 2 C2 2 N1 1 CH3 127.000 3.000
-ACYSNN 1 CH3 2 N1 2 C5 127.000 3.000
-ACYSNN 2 N1 1 CH3 1 HH31 109.470 3.000
-ACYSNN 2 N1 1 CH3 1 HH32 109.470 3.000
-ACYSNN 2 N1 1 CH3 1 C 109.500 3.000
+ACYSNN 1 C 1 CH3 2 N1 113.834 1.50
+ACYSNN 2 N1 1 CH3 1 H1 109.044 1.50
+ACYSNN 2 N1 1 CH3 1 H2 109.044 1.50
+ACYSNN 2 C2 2 N1 1 CH3 123.734 2.62
+ACYSNN 2 C5 2 N1 1 CH3 123.734 2.62
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ACYSNN sp2_sp3_1 2 C2 2 N1 1 CH3 1 C -90.000 10.0 6
+ACYSNN sp2_sp2_1 2 O2 2 C2 2 N1 1 CH3 0.000 5.0 2
+ACYSNN sp2_sp3_2 1 O 1 C 1 CH3 2 N1 120.000 10.0 6
 
 loop_
 _chem_link_plane.link_id
@@ -38472,12 +38615,12 @@ _chem_link_plane.plane_id
 _chem_link_plane.atom_comp_id
 _chem_link_plane.atom_id
 _chem_link_plane.dist_esd
-ACYSNN plan-3 2 N1 0.020
-ACYSNN plan-3 1 CH3 0.020
-ACYSNN plan-3 2 C5 0.020
-ACYSNN plan-3 2 C2 0.020
+ACYSNN plan-2 2 C5 0.020
+ACYSNN plan-2 1 CH3 0.020
+ACYSNN plan-2 2 C2 0.020
+ACYSNN plan-2 2 N1 0.020
 
-data_link_ALASNN
+data_link_pept-SNN
 loop_
 _chem_link_bond.link_id
 _chem_link_bond.atom_1_comp_id
@@ -38487,7 +38630,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-ALASNN 1 C 2 N3 single 1.330 0.020
+pept-SNN 1 C 2 N3 SINGLE 1.338 0.0100
 
 loop_
 _chem_link_angle.link_id
@@ -38499,10 +38642,27 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-ALASNN 2 C3 2 N3 1 C 121.500 3.000
-ALASNN 2 HN31 2 N3 1 C 120.000 3.000
-ALASNN 2 N3 1 C 1 O 123.000 3.000
-ALASNN 2 N3 1 C 1 CA 116.500 3.000
+pept-SNN 1 CA 1 C 2 N3 117.912 3.00
+pept-SNN 1 O 1 C 2 N3 123.381 1.50
+pept-SNN 2 C3 2 N3 1 C 121.847 1.50
+pept-SNN 1 C 2 N3 2 H33 118.403 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-SNN sp2_sp2_1 1 CA 1 C 2 N3 2 C3 180.000 5.0 2
+pept-SNN sp2_sp3_1 1 C 2 N3 2 C3 2 C2 0.000 10.0 6
 
 loop_
 _chem_link_plane.link_id
@@ -38510,12 +38670,14 @@ _chem_link_plane.plane_id
 _chem_link_plane.atom_comp_id
 _chem_link_plane.atom_id
 _chem_link_plane.dist_esd
-ALASNN plan-1 1 C 0.020
-ALASNN plan-1 1 CA 0.020
-ALASNN plan-1 1 O 0.020
-ALASNN plan-1 2 N3 0.020
-ALASNN plan-1 2 C3 0.020
-ALASNN plan-1 2 HN31 0.020
+pept-SNN plan-1 1 CA 0.020
+pept-SNN plan-1 1 C 0.020
+pept-SNN plan-1 2 N3 0.020
+pept-SNN plan-1 1 O 0.020
+pept-SNN plan-4 2 C3 0.020
+pept-SNN plan-4 1 C 0.020
+pept-SNN plan-4 2 H33 0.020
+pept-SNN plan-4 2 N3 0.020
 
 data_link_TPN-TPN
 loop_
@@ -41042,6 +41204,104 @@ _chem_mod_tor.new_value_angle
 _chem_mod_tor.new_value_angle_esd
 CYSmod1 delete CA CB SG HG . .
 
+data_mod_MPRm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+MPRm1 delete HS3 . H HSH1 0
+MPRm1 change S3 . S S2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+MPRm1 delete S3 HS3 single . . . .
+MPRm1 change C3 S3 single 1.817 0.0100 1.817 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+MPRm1 delete C3 S3 HS3 . .
+MPRm1 change C2 C3 S3 112.476 3.00
+MPRm1 change S3 C3 H31 108.769 1.50
+MPRm1 change S3 C3 H32 108.769 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+MPRm1 delete C2 C3 S3 HS3 . .
+
+data_mod_FORm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+FORm1 delete H2 . H H 0
+FORm1 change C . C C1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+FORm1 delete C H2 single . . . .
+FORm1 change C O double 1.229 0.0100 1.229 0.0100
+FORm1 change C H1 single 0.947 0.0100 1.082 0.0130
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+FORm1 delete O C H2 . .
+FORm1 delete H1 C H2 . .
+FORm1 change O C H1 118.402 3.00
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+FORm1 delete plan-1 C 0.020
+FORm1 delete plan-1 H1 0.020
+FORm1 delete plan-1 H2 0.020
+FORm1 delete plan-1 O 0.020
+
 data_mod_NH3
 loop_
 _chem_mod_atom.mod_id
@@ -43090,9 +43350,9 @@ _chem_mod_atom.atom_id
 _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-ACYmod delete HH31 . H H 0.0
-ACYmod change CH3 CH3 C CH2 0.0
+_chem_mod_atom.new_charge
+ACYmod delete H3 . H H 0
+ACYmod change CH3 . C CH2 0
 
 loop_
 _chem_mod_bond.mod_id
@@ -43104,7 +43364,10 @@ _chem_mod_bond.new_value_dist
 _chem_mod_bond.new_value_dist_esd
 _chem_mod_bond.new_value_dist_nucleus
 _chem_mod_bond.new_value_dist_nucleus_esd
-ACYmod delete HH31 CH3 single . . . .
+ACYmod delete CH3 H3 single . . . .
+ACYmod change C CH3 single 1.529 0.0130 1.529 0.0130
+ACYmod change CH3 H1 single 0.977 0.0109 1.089 0.0100
+ACYmod change CH3 H2 single 0.977 0.0109 1.089 0.0100
 
 loop_
 _chem_mod_angle.mod_id
@@ -43114,9 +43377,222 @@ _chem_mod_angle.atom_id_2
 _chem_mod_angle.atom_id_3
 _chem_mod_angle.new_value_angle
 _chem_mod_angle.new_value_angle_esd
-ACYmod delete C CH3 HH31 109.470 3.000
-ACYmod delete HH33 CH3 HH31 109.470 3.000
-ACYmod delete HH32 CH3 HH31 109.470 3.000
+ACYmod delete C CH3 H3 . .
+ACYmod delete H1 CH3 H3 . .
+ACYmod delete H2 CH3 H3 . .
+ACYmod change O C CH3 116.816 3.00
+ACYmod change OXT C CH3 116.816 3.00
+ACYmod change C CH3 H1 108.814 1.50
+ACYmod change C CH3 H2 108.814 1.50
+ACYmod change H1 CH3 H2 108.190 3.00
+
+data_mod_IVAm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+IVAm1 delete OXT . O OC -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+IVAm1 delete C OXT single . . . .
+IVAm1 change CA C single 1.516 0.0100 1.516 0.0100
+IVAm1 change C O double 1.234 0.0183 1.234 0.0183
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+IVAm1 delete CA C OXT . .
+IVAm1 delete O C OXT . .
+IVAm1 change CB CA C 112.394 1.82
+IVAm1 change C CA HA1 109.131 1.50
+IVAm1 change C CA HA2 109.131 1.50
+IVAm1 change CA C O 122.046 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+IVAm1 delete plan-1 C 0.020
+IVAm1 delete plan-1 CA 0.020
+IVAm1 delete plan-1 O 0.020
+IVAm1 delete plan-1 OXT 0.020
+
+data_mod_BOCm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+BOCm1 delete O3 . O OH1 0
+BOCm1 delete H3 . H H 0
+BOCm1 change O2 . O O 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+BOCm1 delete C O3 single . . . .
+BOCm1 delete O3 H3 single . . . .
+BOCm1 change O1 C double 1.217 0.0100 1.217 0.0100
+BOCm1 change C O2 single 1.341 0.0114 1.341 0.0114
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+BOCm1 delete O1 C O3 . .
+BOCm1 delete O2 C O3 . .
+BOCm1 delete C O3 H3 . .
+BOCm1 change O1 C O2 125.546 1.50
+BOCm1 change C O2 CT 120.869 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+BOCm1 delete O1 C O3 H3 . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+BOCm1 delete plan-1 C 0.020
+BOCm1 delete plan-1 O1 0.020
+BOCm1 delete plan-1 O2 0.020
+BOCm1 delete plan-1 O3 0.020
+
+data_mod_NMEm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+NMEm1 delete HN2 . H H 0
+NMEm1 change N . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+NMEm1 delete N HN2 single . . . .
+NMEm1 change N C single 1.451 0.0100 1.451 0.0100
+NMEm1 change N HN1 single 0.871 0.0200 1.016 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+NMEm1 delete C N HN2 . .
+NMEm1 delete HN1 N HN2 . .
+NMEm1 change C N HN1 118.830 3.00
+NMEm1 change N C H1 109.501 1.50
+NMEm1 change N C H2 109.501 1.50
+NMEm1 change N C H3 109.501 1.50
+
+data_mod_SNNmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+SNNmod1 delete HN . H H 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+SNNmod1 delete N1 HN single . . . .
+SNNmod1 change N1 C2 single 1.383 0.0109 1.383 0.0109
+SNNmod1 change N1 C5 single 1.382 0.0100 1.382 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+SNNmod1 delete C2 N1 HN . .
+SNNmod1 delete C5 N1 HN . .
+SNNmod1 change C2 N1 C5 112.532 1.50
+SNNmod1 change N1 C2 C3 108.820 1.50
+SNNmod1 change N1 C2 O2 125.193 1.71
+SNNmod1 change N1 C5 C4 108.523 1.50
+SNNmod1 change N1 C5 O5 124.084 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+SNNmod1 delete plan-1 C2 0.020
+SNNmod1 delete plan-1 C5 0.020
+SNNmod1 delete plan-1 HN 0.020
+SNNmod1 delete plan-1 N1 0.020
 
 data_mod_SNNmod
 loop_
@@ -43126,9 +43602,11 @@ _chem_mod_atom.atom_id
 _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-SNNmod delete HN1 . H H 0.0
-SNNmod change O2 O2 O O 0.0
+_chem_mod_atom.new_charge
+SNNmod delete HN31 . H H 0
+SNNmod delete HN32 . H H 0
+SNNmod change N1 . N NR15 0
+SNNmod change N3 . N NH1 0
 
 loop_
 _chem_mod_bond.mod_id
@@ -43140,7 +43618,10 @@ _chem_mod_bond.new_value_dist
 _chem_mod_bond.new_value_dist_esd
 _chem_mod_bond.new_value_dist_nucleus
 _chem_mod_bond.new_value_dist_nucleus_esd
-SNNmod delete HN1 N1 single . . . .
+SNNmod delete N3 HN31 single . . . .
+SNNmod delete N3 HN32 single . . . .
+SNNmod change C3 N3 single 1.447 0.0100 1.447 0.0100
+SNNmod change N3 H33 single 0.875 0.0126 1.016 0.0100
 
 loop_
 _chem_mod_angle.mod_id
@@ -43150,111 +43631,26 @@ _chem_mod_angle.atom_id_2
 _chem_mod_angle.atom_id_3
 _chem_mod_angle.new_value_angle
 _chem_mod_angle.new_value_angle_esd
-SNNmod delete C5 N1 HN1 120.000 3.000
-SNNmod delete HN1 N1 C2 120.000 3.000
+SNNmod delete C3 N3 HN31 . .
+SNNmod delete C3 N3 HN32 . .
+SNNmod delete HN31 N3 HN32 . .
+SNNmod delete HN31 N3 H33 . .
+SNNmod delete HN32 N3 H33 . .
+SNNmod change C2 C3 N3 111.533 1.50
+SNNmod change N3 C3 C4 114.845 1.50
+SNNmod change N3 C3 H3 108.330 1.50
+SNNmod change C3 N3 H33 119.750 2.24
 
 loop_
-_chem_mod_plane_atom.mod_id
-_chem_mod_plane_atom.function
-_chem_mod_plane_atom.plane_id
-_chem_mod_plane_atom.atom_id
-_chem_mod_plane_atom.new_dist_esd
-SNNmod delete plan-1 HN1 0.020
-SNNmod delete plan-2 HN1 0.020
-SNNmod delete plan-4 HN1 0.020
-
-data_mod_ALAmod
-loop_
-_chem_mod_atom.mod_id
-_chem_mod_atom.function
-_chem_mod_atom.atom_id
-_chem_mod_atom.new_atom_id
-_chem_mod_atom.new_type_symbol
-_chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-ALAmod delete OXT . O OC 0.0
-ALAmod change C C C C 0.0
-
-loop_
-_chem_mod_bond.mod_id
-_chem_mod_bond.function
-_chem_mod_bond.atom_id_1
-_chem_mod_bond.atom_id_2
-_chem_mod_bond.new_type
-_chem_mod_bond.new_value_dist
-_chem_mod_bond.new_value_dist_esd
-_chem_mod_bond.new_value_dist_nucleus
-_chem_mod_bond.new_value_dist_nucleus_esd
-ALAmod delete C OXT deloc . . . .
-ALAmod change O C double 1.220 0.020 1.220 0.020
-
-loop_
-_chem_mod_angle.mod_id
-_chem_mod_angle.function
-_chem_mod_angle.atom_id_1
-_chem_mod_angle.atom_id_2
-_chem_mod_angle.atom_id_3
-_chem_mod_angle.new_value_angle
-_chem_mod_angle.new_value_angle_esd
-ALAmod delete CA C OXT 121.000 3.000
-ALAmod delete O C OXT 118.000 3.000
-
-loop_
-_chem_mod_plane_atom.mod_id
-_chem_mod_plane_atom.function
-_chem_mod_plane_atom.plane_id
-_chem_mod_plane_atom.atom_id
-_chem_mod_plane_atom.new_dist_esd
-ALAmod delete oxt OXT 0.020
-
-data_mod_SNNmd1
-loop_
-_chem_mod_atom.mod_id
-_chem_mod_atom.function
-_chem_mod_atom.atom_id
-_chem_mod_atom.new_atom_id
-_chem_mod_atom.new_type_symbol
-_chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-SNNmd1 delete HN31 . H H 0.0
-SNNmd1 change O2 O2 O O 0.0
-
-loop_
-_chem_mod_bond.mod_id
-_chem_mod_bond.function
-_chem_mod_bond.atom_id_1
-_chem_mod_bond.atom_id_2
-_chem_mod_bond.new_type
-_chem_mod_bond.new_value_dist
-_chem_mod_bond.new_value_dist_esd
-_chem_mod_bond.new_value_dist_nucleus
-_chem_mod_bond.new_value_dist_nucleus_esd
-SNNmd1 delete HN31 N3 single . . . .
-
-loop_
-_chem_mod_angle.mod_id
-_chem_mod_angle.function
-_chem_mod_angle.atom_id_1
-_chem_mod_angle.atom_id_2
-_chem_mod_angle.atom_id_3
-_chem_mod_angle.new_value_angle
-_chem_mod_angle.new_value_angle_esd
-SNNmd1 delete C3 N3 HN31 120.000 3.000
-SNNmd1 delete HN32 N3 HN31 120.000 3.000
-
-loop_
-_chem_mod_plane_atom.mod_id
-_chem_mod_plane_atom.function
-_chem_mod_plane_atom.plane_id
-_chem_mod_plane_atom.atom_id
-_chem_mod_plane_atom.new_dist_esd
-SNNmd1 add plan-2 HN11 0.020
-SNNmd1 add plan-3 HN11 0.020
-SNNmd1 add plan-5 HN11 0.020
-SNNmd1 delete plan-1 HN1 0.020
-SNNmd1 delete plan-2 HN1 0.020
-SNNmd1 delete plan-3 HN32 0.020
-SNNmd1 delete plan-4 HN1 0.020
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+SNNmod delete C2 C3 N3 HN31 . .
 
 data_mod_TPNmodC
 loop_


### PR DESCRIPTION
During a test of gemmi, found several link restraints were insufficient to define hydrogen positions (as gemmi failed). Following links have been updated using Acedrg 269.

| link | instruction | pdb |
|--|--|--|
| CYS-MPR | LINK: RES-NAME-1 CYS ATOM-NAME-1 SG RES-NAME-2 MPR ATOM-NAME-2 S3 | 3d1l |
| FOR_C-N | LINK: RES-NAME-1 FOR ATOM-NAME-1 C RES-NAME-2 ALA ATOM-NAME-2 N | 1jlx |
| IVA_C-N | LINK: RES-NAME-1 IVA ATOM-NAME-1 C RES-NAME-2 ALA ATOM-NAME-2 N DELETE ATOM OXT 1  | 1apt |
| BOC_C-N | LINK: RES-NAME-1 BOC ATOM-NAME-1 C RES-NAME-2 ALA ATOM-NAME-2 N DELETE ATOM O3 1 | 7agb |
| NME_N-C | LINK: RES-NAME-1 ALA ATOM-NAME-1 C RES-NAME-2 NME ATOM-NAME-2 N DELETE ATOM OXT 1 | 4bea |
| ACYSNN | LINK: RES-NAME-1 ACY ATOM-NAME-1 CH3 RES-NAME-2 SNN ATOM-NAME-2 N1 | 7aby |
| ALASNN | LINK: RES-NAME-1 ALA ATOM-NAME-1 C RES-NAME-2 SNN ATOM-NAME-2 N3 DELETE ATOM OXT 1 | 6a56 |

ALASNN was renamed to pept-SNN. Regarding ACYSNN, I think ACE should be used instead of ACY, but it's already used in several PDB models.