### PR TITLE
fix ASX and GLX

### DIFF
--- a/a/ASX.cif
+++ b/a/ASX.cif
@@ -7,7 +7,7 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-ASX ASX "ASP/ASN AMBIGUOUS" peptide 18 9 .
+ASX ASX "ASP/ASN AMBIGUOUS" peptide 15 9 .
 
 data_comp_ASX
 loop_
@@ -19,21 +19,43 @@ _chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-ASX N   N NT3 1  0.810  1.623  -0.362
-ASX CA  C CH1 0  0.440  0.179  -0.398
-ASX C   C C   0  -1.000 0.013  0.101
-ASX O   O O   0  -1.296 0.563  1.184
-ASX CB  C CH2 0  1.402  -0.668 0.430
-ASX CG  C C   0  2.817  -0.752 -0.096
-ASX XD1 N NH1 0  3.132  -0.433 -1.316
-ASX XD2 N NH2 0  3.727  -1.188 0.789
-ASX OXT O OC  -1 -1.777 -0.661 -0.612
-ASX H   H H   0  1.584  1.761  -0.804
-ASX H2  H H   0  0.911  1.891  0.493
-ASX H3  H H   0  0.169  2.125  -0.751
-ASX HA  H H   0  0.482  -0.127 -1.332
-ASX HB1 H H   0  1.038  -1.576 0.496
-ASX HB2 H H   0  1.424  -0.298 1.337
+ASX N N NT3 1 33.498 17.725 39.115
+ASX CA C CH1 0 34.953 17.538 38.806
+ASX C C C 0 35.108 16.849 37.444
+ASX O O O 0 36.213 16.753 36.911
+ASX CB C CH2 0 35.671 16.767 39.920
+ASX CG C C 0 35.053 15.428 40.299
+ASX XD1 O O 0 35.700 14.690 41.067
+ASX XD2 O OC -1 33.927 15.137 39.844
+ASX OXT O OC -1 34.141 16.373 36.847
+ASX H H H 0 33.388 17.948 40.095
+ASX H2 H H 0 33.001 16.928 38.913
+ASX H3 H H 0 33.156 18.451 38.588
+ASX HA H H 0 35.365 18.432 38.746
+ASX HB3 H H 0 35.693 17.326 40.723
+ASX HB2 H H 0 36.595 16.604 39.641
+
+loop_
+_chem_comp_tree.comp_id
+_chem_comp_tree.atom_id
+_chem_comp_tree.atom_back
+_chem_comp_tree.atom_forward
+_chem_comp_tree.connect_type
+ASX N n/a CA START
+ASX H N . .
+ASX H2 N . .
+ASX H3 N . .
+ASX CA N C .
+ASX HA CA . .
+ASX CB CA CG .
+ASX HB3 CB . .
+ASX HB2 CB . .
+ASX CG CB XD2 .
+ASX XD1 CG . .
+ASX XD2 CG . .
+ASX C CA . END
+ASX O C . .
+ASX OXT C . .
 
 loop_
 _chem_comp_bond.comp_id
@@ -45,20 +67,20 @@ _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-ASX N  CA  SINGLE n 1.490 0.0100 1.490 0.0100
-ASX CA C   SINGLE n 1.533 0.0100 1.533 0.0100
-ASX CA CB  SINGLE n 1.524 0.0100 1.524 0.0100
-ASX C  O   DOUBLE n 1.251 0.0183 1.251 0.0183
-ASX C  OXT SINGLE n 1.251 0.0183 1.251 0.0183
-ASX CB CG  SINGLE n 1.505 0.0161 1.505 0.0161
-ASX CG XD1 DOUBLE n 1.297 0.0200 1.297 0.0200
-ASX CG XD2 SINGLE n 1.338 0.0163 1.338 0.0163
-ASX N  H   SINGLE n 1.036 0.0160 0.902 0.0102
-ASX N  H2  SINGLE n 1.036 0.0160 0.902 0.0102
-ASX N  H3  SINGLE n 1.036 0.0160 0.902 0.0102
-ASX CA HA  SINGLE n 1.089 0.0100 0.984 0.0200
-ASX CB HB1 SINGLE n 1.089 0.0100 0.980 0.0165
-ASX CB HB2 SINGLE n 1.089 0.0100 0.980 0.0165
+ASX N CA SINGLE n 1.488 0.0100 1.488 0.0100
+ASX CA C SINGLE n 1.533 0.0100 1.533 0.0100
+ASX CA CB SINGLE n 1.531 0.0107 1.531 0.0107
+ASX C O DOUBLE n 1.247 0.0187 1.247 0.0187
+ASX C OXT SINGLE n 1.247 0.0187 1.247 0.0187
+ASX CB CG SINGLE n 1.519 0.0109 1.519 0.0109
+ASX CG XD1 DOUBLE n 1.247 0.0187 1.247 0.0187
+ASX CG XD2 SINGLE n 1.247 0.0187 1.247 0.0187
+ASX N H SINGLE n 1.036 0.0160 0.911 0.0200
+ASX N H2 SINGLE n 1.036 0.0160 0.911 0.0200
+ASX N H3 SINGLE n 1.036 0.0160 0.911 0.0200
+ASX CA HA SINGLE n 1.089 0.0100 0.986 0.0200
+ASX CB HB3 SINGLE n 1.089 0.0100 0.979 0.0159
+ASX CB HB2 SINGLE n 1.089 0.0100 0.979 0.0159
 
 loop_
 _chem_comp_angle.comp_id
@@ -67,30 +89,30 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-ASX CA  N  H   109.990 3.00
-ASX CA  N  H2  109.990 3.00
-ASX CA  N  H3  109.990 3.00
-ASX H   N  H2  109.032 3.00
-ASX H   N  H3  109.032 3.00
-ASX H2  N  H3  109.032 3.00
-ASX N   CA C   109.258 1.50
-ASX N   CA CB  111.384 1.50
-ASX N   CA HA  108.387 1.58
-ASX C   CA CB  111.904 3.00
-ASX C   CA HA  108.774 1.79
-ASX CB  CA HA  108.323 1.98
-ASX CA  C  O   117.148 1.60
-ASX CA  C  OXT 117.148 1.60
-ASX O   C  OXT 125.704 1.50
-ASX CA  CB CG  111.339 3.00
-ASX CA  CB HB1 108.967 2.63
-ASX CA  CB HB2 108.967 2.63
-ASX CG  CB HB1 108.942 1.50
-ASX CG  CB HB2 108.942 1.50
-ASX HB1 CB HB2 107.705 2.23
-ASX CB  CG XD1 121.049 3.00
-ASX CB  CG XD2 114.843 1.50
-ASX XD1 CG XD2 124.109 3.00
+ASX CA N H 110.062 1.93
+ASX CA N H2 110.062 1.93
+ASX CA N H3 110.062 1.93
+ASX H N H2 109.028 2.41
+ASX H N H3 109.028 2.41
+ASX H2 N H3 109.028 2.41
+ASX N CA C 109.241 1.50
+ASX N CA CB 111.338 1.50
+ASX N CA HA 108.487 1.50
+ASX C CA CB 111.804 2.58
+ASX C CA HA 108.824 1.50
+ASX CB CA HA 108.666 1.69
+ASX CA C O 117.124 1.50
+ASX CA C OXT 117.124 1.50
+ASX O C OXT 125.752 1.50
+ASX CA CB CG 113.398 1.64
+ASX CA CB HB3 108.488 2.17
+ASX CA CB HB2 108.488 2.17
+ASX CG CB HB3 107.840 2.14
+ASX CG CB HB2 107.840 2.14
+ASX HB3 CB HB2 107.891 1.66
+ASX CB CG XD1 117.986 1.50
+ASX CB CG XD2 117.986 1.50
+ASX XD1 CG XD2 124.027 1.50
 
 loop_
 _chem_comp_tor.comp_id
@@ -102,10 +124,10 @@ _chem_comp_tor.atom_id_4
 _chem_comp_tor.value_angle
 _chem_comp_tor.value_angle_esd
 _chem_comp_tor.period
-ASX chi1      N   CA CB CG  -60.000 10.0 3
-ASX sp3_sp3_1 C   CA N  H   180.000 10.0 3
-ASX sp2_sp3_7 XD1 CG CB HB1 0.000   10.0 6
-ASX sp2_sp3_1 O   C  CA N   0.000   10.0 6
+ASX chi1 N CA CB CG 60.000 10.0 3
+ASX chi2 CA CB CG XD1 180.000 10.0 6
+ASX sp3_sp3_1 C CA N H 180.000 10.0 3
+ASX sp2_sp3_1 O C CA N 0.000 10.0 6
 
 loop_
 _chem_comp_chir.comp_id
@@ -122,12 +144,12 @@ _chem_comp_plane_atom.comp_id
 _chem_comp_plane_atom.plane_id
 _chem_comp_plane_atom.atom_id
 _chem_comp_plane_atom.dist_esd
-ASX plan-1 C   0.020
-ASX plan-1 CA  0.020
-ASX plan-1 O   0.020
+ASX plan-1 C 0.020
+ASX plan-1 CA 0.020
+ASX plan-1 O 0.020
 ASX plan-1 OXT 0.020
-ASX plan-2 CB  0.020
-ASX plan-2 CG  0.020
+ASX plan-2 CB 0.020
+ASX plan-2 CG 0.020
 ASX plan-2 XD1 0.020
 ASX plan-2 XD2 0.020
 
@@ -137,17 +159,20 @@ _pdbx_chem_comp_descriptor.type
 _pdbx_chem_comp_descriptor.program
 _pdbx_chem_comp_descriptor.program_version
 _pdbx_chem_comp_descriptor.descriptor
-ASX SMILES_CANONICAL CACTVS               3.370 "C(C[C@H](N)C(O)=O)(=[F,Cl,Br,I])[F,Cl,Br,I]"
-ASX SMILES           CACTVS               3.370 "C(C[CH](N)C(O)=O)(=[F,Cl,Br,I])[F,Cl,Br,I]"
-ASX SMILES_CANONICAL "OpenEye OEToolkits" 1.7.2 "*=C(*)C[C@@H](C(=O)O)N"
-ASX SMILES           "OpenEye OEToolkits" 1.7.2 "*=C(*)CC(C(=O)O)N"
+ASX SMILES ACDLabs 12.01 O=C(O)CC(N)C(=O)O
+ASX SMILES_CANONICAL CACTVS 3.370 N[C@@H](CC(O)=O)C(O)=O
+ASX SMILES CACTVS 3.370 N[CH](CC(O)=O)C(O)=O
+ASX SMILES_CANONICAL "OpenEye OEToolkits" 1.7.0 C([C@@H](C(=O)O)N)C(=O)O
+ASX SMILES "OpenEye OEToolkits" 1.7.0 C(C(C(=O)O)N)C(=O)O
+ASX InChI InChI 1.03 InChI=1S/C4H7NO4/c5-2(4(8)9)1-3(6)7/h2H,1,5H2,(H,6,7)(H,8,9)/t2-/m0/s1
+ASX InChIKey InChI 1.03 CKLJMWTZIZZHCS-REOHCLBHSA-N
 
 loop_
 _pdbx_chem_comp_description_generator.comp_id
 _pdbx_chem_comp_description_generator.program_name
 _pdbx_chem_comp_description_generator.program_version
 _pdbx_chem_comp_description_generator.descriptor
-ASX acedrg          270       "dictionary generator"
-ASX acedrg_database 12        "data source"
-ASX rdkit           2019.09.1 "Chemoinformatics tool"
-ASX refmac5         5.8.0403  "optimization tool"
+ASX acedrg 243 "dictionary generator"
+ASX acedrg_database 11 "data source"
+ASX rdkit 2017.03.2 "Chemoinformatics tool"
+ASX refmac5 5.8.0238 "optimization tool"

--- a/a/ASX.cif
+++ b/a/ASX.cif
@@ -1,11 +1,3 @@
-global_
-_lib_name         ?
-_lib_version      ?
-_lib_update       ?
-# ------------------------------------------------
-#
-# ---   LIST OF MONOMERS ---
-#
 data_comp_list
 loop_
 _chem_comp.id
@@ -15,84 +7,59 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-ASX      ASX 'ASP/ASN AMBIGUOUS                   ' peptide            17   9 .
-# ------------------------------------------------------
-# ------------------------------------------------------
-#
-# --- DESCRIPTION OF MONOMERS ---
-#
+ASX ASX "ASP/ASN AMBIGUOUS" peptide 18 9 .
+
 data_comp_ASX
-#
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
-_chem_comp_atom.partial_charge
+_chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
- ASX           N      N    N1       -1.000      0.000    0.000    0.000
- ASX           H      H    HNH1      0.000     -0.488    0.101    0.819
- ASX           CA     C    CH1       0.000      0.979    1.092   -0.119
- ASX           HA     H    H         0.000      1.377    1.068    0.776
- ASX           CB     C    CH2       0.000      2.240    0.880   -0.987
- ASX           HB2    H    H         0.000      2.415    1.452   -1.750
- ASX           CG     C    C         0.000      3.202   -0.242   -0.625
- ASX           XD1    N    NH2       0.000      4.109   -0.658   -1.334
- ASX           HD11   H    H         0.000      4.755   -1.342   -1.043
- ASX           HD12   H    H         0.000      4.149   -0.358   -2.261
- ASX           XD2    N    NH2       0.000      3.461   -0.342    0.728
- ASX           HD21   H    H         0.000      3.518   -1.299    1.044
- ASX           HD22   H    H         0.000      3.370    0.329    1.520
- ASX           HB1    H    H         0.000      3.461    1.031    1.734
- ASX           C      C    C         0.000      0.433    2.517   -0.138
- ASX           O      O    OC       -0.500     -0.715    2.811   -0.452
- ASX           OXT    O    OC       -0.500      0.939    3.314    0.681
-loop_
-_chem_comp_tree.comp_id
-_chem_comp_tree.atom_id
-_chem_comp_tree.atom_back
-_chem_comp_tree.atom_forward
-_chem_comp_tree.connect_type
- ASX      N      n/a    CA     START
- ASX      H      N      .      .
- ASX      CA     N      C      .
- ASX      HA     CA     .      .
- ASX      CB     CA     CG     .
- ASX      HB2    CB     .      .
- ASX      CG     CB     XD2    .
- ASX      XD1    CG     HD12   .
- ASX      HD11   XD1    .      .
- ASX      HD12   XD1    .      .
- ASX      XD2    CG     HD22   .
- ASX      HD21   XD2    .      .
- ASX      HD22   XD2    .      .
- ASX      C      CA     OXT    .
- ASX      O      C      .      .
- ASX      OXT    C      .      END
+ASX N   N NT3 1  0.810  1.623  -0.362
+ASX CA  C CH1 0  0.440  0.179  -0.398
+ASX C   C C   0  -1.000 0.013  0.101
+ASX O   O O   0  -1.296 0.563  1.184
+ASX CB  C CH2 0  1.402  -0.668 0.430
+ASX CG  C C   0  2.817  -0.752 -0.096
+ASX XD1 N NH1 0  3.132  -0.433 -1.316
+ASX XD2 N NH2 0  3.727  -1.188 0.789
+ASX OXT O OC  -1 -1.777 -0.661 -0.612
+ASX H   H H   0  1.584  1.761  -0.804
+ASX H2  H H   0  0.911  1.891  0.493
+ASX H3  H H   0  0.169  2.125  -0.751
+ASX HA  H H   0  0.482  -0.127 -1.332
+ASX HB1 H H   0  1.038  -1.576 0.496
+ASX HB2 H H   0  1.424  -0.298 1.337
+
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
 _chem_comp_bond.type
+_chem_comp_bond.aromatic
+_chem_comp_bond.value_dist_nucleus
+_chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
- ASX      N      CA        single      1.491    0.021
- ASX      CA     HA        single      0.980    0.020
- ASX      CA     CB        single      1.530    0.020
- ASX      CB     HB2       single      0.970    0.020
- ASX      CB     CG        single      1.516    0.020
- ASX      CG     XD1       deloc       1.231    0.019
- ASX      CG     XD2       deloc       1.328    0.021
- ASX      XD1    HD11      single      0.980    0.020
- ASX      XD1    HD12      single      0.980    0.020
- ASX      XD2    HD21      single      0.980    0.020
- ASX      XD2    HD22      single      0.980    0.020
- ASX      CA     C         single      1.525    0.021
- ASX      C      O         deloc       1.231    0.020
- ASX      N      H         single      1.010    0.020
- ASX      C      OXT       deloc       1.231    0.020
+ASX N  CA  SINGLE n 1.490 0.0100 1.490 0.0100
+ASX CA C   SINGLE n 1.533 0.0100 1.533 0.0100
+ASX CA CB  SINGLE n 1.524 0.0100 1.524 0.0100
+ASX C  O   DOUBLE n 1.251 0.0183 1.251 0.0183
+ASX C  OXT SINGLE n 1.251 0.0183 1.251 0.0183
+ASX CB CG  SINGLE n 1.505 0.0161 1.505 0.0161
+ASX CG XD1 DOUBLE n 1.297 0.0200 1.297 0.0200
+ASX CG XD2 SINGLE n 1.338 0.0163 1.338 0.0163
+ASX N  H   SINGLE n 1.036 0.0160 0.902 0.0102
+ASX N  H2  SINGLE n 1.036 0.0160 0.902 0.0102
+ASX N  H3  SINGLE n 1.036 0.0160 0.902 0.0102
+ASX CA HA  SINGLE n 1.089 0.0100 0.984 0.0200
+ASX CB HB1 SINGLE n 1.089 0.0100 0.980 0.0165
+ASX CB HB2 SINGLE n 1.089 0.0100 0.980 0.0165
+
 loop_
 _chem_comp_angle.comp_id
 _chem_comp_angle.atom_id_1
@@ -100,31 +67,31 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
- ASX      O      C      CA      121.000    3.000
- ASX      C      CA     HA      108.810    3.000
- ASX      C      CA     N       109.470    3.000
- ASX      C      CA     CB      109.470    3.000
- ASX      HA     CA     N       109.470    3.000
- ASX      HA     CA     CB      108.340    3.000
- ASX      N      CA     CB      109.470    3.000
- ASX      CA     CB     HB1     109.470    3.000
- ASX      CA     CB     HB2     109.470    3.000
- ASX      CA     CB     CG      111.000    3.000
- ASX      HB1    CB     HB2     107.900    3.000
- ASX      HB1    CB     CG      109.470    3.000
- ASX      HB2    CB     CG      109.470    3.000
- ASX      CB     CG     XD2     120.000    3.000
- ASX      CB     CG     XD1     120.000    3.000
- ASX      XD2    CG     XD1     120.000    3.000
- ASX      CG     XD2    HD22    120.000    3.000
- ASX      CG     XD2    HD21    120.000    3.000
- ASX      HD22   XD2    HD21    120.000    3.000
- ASX      CG     XD1    HD12    120.000    3.000
- ASX      CG     XD1    HD11    120.000    3.000
- ASX      HD12   XD1    HD11    120.000    3.000
- ASX      H      N      CA      114.470    3.000
- ASX      CA     C      OXT     121.000    3.000
- ASX      O      C      OXT     118.000    3.000
+ASX CA  N  H   109.990 3.00
+ASX CA  N  H2  109.990 3.00
+ASX CA  N  H3  109.990 3.00
+ASX H   N  H2  109.032 3.00
+ASX H   N  H3  109.032 3.00
+ASX H2  N  H3  109.032 3.00
+ASX N   CA C   109.258 1.50
+ASX N   CA CB  111.384 1.50
+ASX N   CA HA  108.387 1.58
+ASX C   CA CB  111.904 3.00
+ASX C   CA HA  108.774 1.79
+ASX CB  CA HA  108.323 1.98
+ASX CA  C  O   117.148 1.60
+ASX CA  C  OXT 117.148 1.60
+ASX O   C  OXT 125.704 1.50
+ASX CA  CB CG  111.339 3.00
+ASX CA  CB HB1 108.967 2.63
+ASX CA  CB HB2 108.967 2.63
+ASX CG  CB HB1 108.942 1.50
+ASX CG  CB HB2 108.942 1.50
+ASX HB1 CB HB2 107.705 2.23
+ASX CB  CG XD1 121.049 3.00
+ASX CB  CG XD2 114.843 1.50
+ASX XD1 CG XD2 124.109 3.00
+
 loop_
 _chem_comp_tor.comp_id
 _chem_comp_tor.id
@@ -135,13 +102,11 @@ _chem_comp_tor.atom_id_4
 _chem_comp_tor.value_angle
 _chem_comp_tor.value_angle_esd
 _chem_comp_tor.period
- ASX      var_1            O      C      CA     CB              -144.432           20.000   1
- ASX      var_3            C      CA     CB     CG               163.160           20.000   3
- ASX      var_4            CA     CB     CG     XD1              170.581           20.000   3
- ASX      var_5            CB     CG     XD2    HD21             175.000           20.000   1
- ASX      var_6            CB     CG     XD1    HD11             175.000           20.000   1
- ASX      psi              N      CA     C      OXT              160.000           30.000   2
- ASX      var_1            C      CA     N      H                180.000           20.000   3
+ASX chi1      N   CA CB CG  -60.000 10.0 3
+ASX sp3_sp3_1 C   CA N  H   180.000 10.0 3
+ASX sp2_sp3_7 XD1 CG CB HB1 0.000   10.0 6
+ASX sp2_sp3_1 O   C  CA N   0.000   10.0 6
+
 loop_
 _chem_comp_chir.comp_id
 _chem_comp_chir.id
@@ -150,26 +115,39 @@ _chem_comp_chir.atom_id_1
 _chem_comp_chir.atom_id_2
 _chem_comp_chir.atom_id_3
 _chem_comp_chir.volume_sign
- ASX      chir_01          CA     N      C      CB        positiv
+ASX chir_1 CA N C CB positive
+
 loop_
 _chem_comp_plane_atom.comp_id
 _chem_comp_plane_atom.plane_id
 _chem_comp_plane_atom.atom_id
 _chem_comp_plane_atom.dist_esd
- ASX      plan-2            CB        0.020
- ASX      plan-2            CG        0.020
- ASX      plan-2            XD1       0.020
- ASX      plan-2            XD2       0.020
- ASX      plan-3            XD1       0.020
- ASX      plan-3            CG        0.020
- ASX      plan-3            HD11      0.020
- ASX      plan-3            HD12      0.020
- ASX      plan-4            XD2       0.020
- ASX      plan-4            CG        0.020
- ASX      plan-4            HD21      0.020
- ASX      plan-4            HD22      0.020
- ASX      oxt               C         0.020
- ASX      oxt               CA        0.020
- ASX      oxt               O         0.020
- ASX      oxt               OXT       0.020
-# ------------------------------------------------------
+ASX plan-1 C   0.020
+ASX plan-1 CA  0.020
+ASX plan-1 O   0.020
+ASX plan-1 OXT 0.020
+ASX plan-2 CB  0.020
+ASX plan-2 CG  0.020
+ASX plan-2 XD1 0.020
+ASX plan-2 XD2 0.020
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+ASX SMILES_CANONICAL CACTVS               3.370 "C(C[C@H](N)C(O)=O)(=[F,Cl,Br,I])[F,Cl,Br,I]"
+ASX SMILES           CACTVS               3.370 "C(C[CH](N)C(O)=O)(=[F,Cl,Br,I])[F,Cl,Br,I]"
+ASX SMILES_CANONICAL "OpenEye OEToolkits" 1.7.2 "*=C(*)C[C@@H](C(=O)O)N"
+ASX SMILES           "OpenEye OEToolkits" 1.7.2 "*=C(*)CC(C(=O)O)N"
+
+loop_
+_pdbx_chem_comp_description_generator.comp_id
+_pdbx_chem_comp_description_generator.program_name
+_pdbx_chem_comp_description_generator.program_version
+_pdbx_chem_comp_description_generator.descriptor
+ASX acedrg          270       "dictionary generator"
+ASX acedrg_database 12        "data source"
+ASX rdkit           2019.09.1 "Chemoinformatics tool"
+ASX refmac5         5.8.0403  "optimization tool"

--- a/g/GLX.cif
+++ b/g/GLX.cif
@@ -7,7 +7,7 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-GLX GLX "GLU/GLN AMBIGUOUS" peptide 21 10 .
+GLX GLX "GLU/GLN AMBIGUOUS" peptide 18 10 .
 
 data_comp_GLX
 loop_
@@ -19,24 +19,49 @@ _chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-GLX N   N NT3 1  -0.090 1.866  0.638
-GLX CA  C CH1 0  0.098  0.409  0.405
-GLX C   C C   0  1.472  0.174  -0.247
-GLX O   O O   0  1.672  0.704  -1.362
-GLX CB  C CH2 0  -1.031 -0.145 -0.466
-GLX CG  C CH2 0  -2.352 -0.317 0.278
-GLX CD  C C   0  -3.385 -1.079 -0.507
-GLX XE1 N NH1 0  -3.779 -2.254 -0.125
-GLX XE2 N NH2 0  -3.847 -0.454 -1.600
-GLX OXT O OC  -1 2.290  -0.531 0.384
-GLX H   H H   0  -0.877 2.016  1.051
-GLX H2  H H   0  -0.084 2.307  -0.149
-GLX H3  H H   0  0.574  2.186  1.158
-GLX HA  H H   0  0.082  -0.051 1.283
-GLX HB1 H H   0  -0.756 -1.015 -0.827
-GLX HB2 H H   0  -1.170 0.461  -1.224
-GLX HG1 H H   0  -2.712 0.576  0.499
-GLX HG2 H H   0  -2.181 -0.793 1.127
+GLX N N NT3 1 88.357 -7.802 -10.134
+GLX CA C CH1 0 87.699 -7.178 -11.327
+GLX C C C 0 88.384 -5.844 -11.650
+GLX O O O 0 88.483 -4.961 -10.798
+GLX CB C CH2 0 86.204 -6.964 -11.076
+GLX CG C CH2 0 85.424 -8.250 -10.867
+GLX CD C C 0 83.927 -8.058 -10.695
+GLX XE1 O O 0 83.291 -7.522 -11.624
+GLX XE2 O OC -1 83.402 -8.445 -9.633
+GLX OXT O OC -1 88.850 -5.625 -12.768
+GLX H H H 0 88.037 -7.348 -9.291
+GLX H2 H H 0 89.312 -7.716 -10.198
+GLX H3 H H 0 88.137 -8.736 -10.096
+GLX HA H H 0 87.810 -7.784 -12.095
+GLX HB3 H H 0 85.825 -6.484 -11.843
+GLX HB2 H H 0 86.098 -6.395 -10.285
+GLX HG3 H H 0 85.769 -8.706 -10.071
+GLX HG2 H H 0 85.574 -8.841 -11.635
+
+loop_
+_chem_comp_tree.comp_id
+_chem_comp_tree.atom_id
+_chem_comp_tree.atom_back
+_chem_comp_tree.atom_forward
+_chem_comp_tree.connect_type
+GLX N n/a CA START
+GLX H N . .
+GLX H2 N . .
+GLX H3 N . .
+GLX CA N C .
+GLX HA CA . .
+GLX CB CA CG .
+GLX HB3 CB . .
+GLX HB2 CB . .
+GLX CG CB CD .
+GLX HG3 CG . .
+GLX HG2 CG . .
+GLX CD CG XE2 .
+GLX XE1 CD . .
+GLX XE2 CD . .
+GLX C CA . END
+GLX O C . .
+GLX OXT C . .
 
 loop_
 _chem_comp_bond.comp_id
@@ -48,23 +73,23 @@ _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-GLX N  CA  SINGLE n 1.487 0.0100 1.487 0.0100
-GLX CA C   SINGLE n 1.538 0.0113 1.538 0.0113
-GLX CA CB  SINGLE n 1.529 0.0100 1.529 0.0100
-GLX C  O   DOUBLE n 1.251 0.0183 1.251 0.0183
-GLX C  OXT SINGLE n 1.251 0.0183 1.251 0.0183
-GLX CB CG  SINGLE n 1.526 0.0100 1.526 0.0100
-GLX CG CD  SINGLE n 1.504 0.0100 1.504 0.0100
-GLX CD XE1 DOUBLE n 1.297 0.0200 1.297 0.0200
-GLX CD XE2 SINGLE n 1.338 0.0163 1.338 0.0163
-GLX N  H   SINGLE n 1.036 0.0160 0.902 0.0102
-GLX N  H2  SINGLE n 1.036 0.0160 0.902 0.0102
-GLX N  H3  SINGLE n 1.036 0.0160 0.902 0.0102
-GLX CA HA  SINGLE n 1.089 0.0100 0.991 0.0200
-GLX CB HB1 SINGLE n 1.089 0.0100 0.980 0.0168
-GLX CB HB2 SINGLE n 1.089 0.0100 0.980 0.0168
-GLX CG HG1 SINGLE n 1.089 0.0100 0.988 0.0100
-GLX CG HG2 SINGLE n 1.089 0.0100 0.988 0.0100
+GLX N CA SINGLE n 1.488 0.0100 1.488 0.0100
+GLX CA C SINGLE n 1.533 0.0100 1.533 0.0100
+GLX CA CB SINGLE n 1.530 0.0105 1.530 0.0105
+GLX C O DOUBLE n 1.247 0.0187 1.247 0.0187
+GLX C OXT SINGLE n 1.247 0.0187 1.247 0.0187
+GLX CB CG SINGLE n 1.518 0.0153 1.518 0.0153
+GLX CG CD SINGLE n 1.519 0.0109 1.519 0.0109
+GLX CD XE1 DOUBLE n 1.247 0.0187 1.247 0.0187
+GLX CD XE2 SINGLE n 1.247 0.0187 1.247 0.0187
+GLX N H SINGLE n 1.036 0.0160 0.911 0.0200
+GLX N H2 SINGLE n 1.036 0.0160 0.911 0.0200
+GLX N H3 SINGLE n 1.036 0.0160 0.911 0.0200
+GLX CA HA SINGLE n 1.089 0.0100 0.985 0.0200
+GLX CB HB3 SINGLE n 1.089 0.0100 0.980 0.0178
+GLX CB HB2 SINGLE n 1.089 0.0100 0.980 0.0178
+GLX CG HG3 SINGLE n 1.089 0.0100 0.981 0.0185
+GLX CG HG2 SINGLE n 1.089 0.0100 0.981 0.0185
 
 loop_
 _chem_comp_angle.comp_id
@@ -73,36 +98,36 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-GLX CA  N  H   109.990 3.00
-GLX CA  N  H2  109.990 3.00
-GLX CA  N  H3  109.990 3.00
-GLX H   N  H2  109.032 3.00
-GLX H   N  H3  109.032 3.00
-GLX H2  N  H3  109.032 3.00
-GLX N   CA C   109.258 1.50
-GLX N   CA CB  110.440 2.46
-GLX N   CA HA  108.387 1.58
-GLX C   CA CB  111.059 3.00
-GLX C   CA HA  108.774 1.79
-GLX CB  CA HA  109.080 2.33
-GLX CA  C  O   117.148 1.60
-GLX CA  C  OXT 117.148 1.60
-GLX O   C  OXT 125.704 1.50
-GLX CA  CB CG  113.457 1.50
-GLX CA  CB HB1 108.677 1.74
-GLX CA  CB HB2 108.677 1.74
-GLX CG  CB HB1 108.873 1.50
-GLX CG  CB HB2 108.873 1.50
-GLX HB1 CB HB2 107.655 1.50
-GLX CB  CG CD  113.605 3.00
-GLX CB  CG HG1 108.870 1.50
-GLX CB  CG HG2 108.870 1.50
-GLX CD  CG HG1 108.942 1.50
-GLX CD  CG HG2 108.942 1.50
-GLX HG1 CG HG2 107.856 1.50
-GLX CG  CD XE1 121.049 3.00
-GLX CG  CD XE2 114.843 1.50
-GLX XE1 CD XE2 124.109 3.00
+GLX CA N H 110.062 1.93
+GLX CA N H2 110.062 1.93
+GLX CA N H3 110.062 1.93
+GLX H N H2 109.028 2.41
+GLX H N H3 109.028 2.41
+GLX H2 N H3 109.028 2.41
+GLX N CA C 109.241 1.50
+GLX N CA CB 110.374 1.62
+GLX N CA HA 108.487 1.50
+GLX C CA CB 111.037 2.40
+GLX C CA HA 108.824 1.50
+GLX CB CA HA 108.967 1.50
+GLX CA C O 117.124 1.50
+GLX CA C OXT 117.124 1.50
+GLX O C OXT 125.752 1.50
+GLX CA CB CG 113.445 1.50
+GLX CA CB HB3 108.549 1.50
+GLX CA CB HB2 108.549 1.50
+GLX CG CB HB3 108.890 1.50
+GLX CG CB HB2 108.890 1.50
+GLX HB3 CB HB2 107.844 1.50
+GLX CB CG CD 114.629 2.24
+GLX CB CG HG3 108.906 1.50
+GLX CB CG HG2 108.906 1.50
+GLX CD CG HG3 108.404 1.50
+GLX CD CG HG2 108.404 1.50
+GLX HG3 CG HG2 107.521 1.50
+GLX CG CD XE1 118.214 1.64
+GLX CG CD XE2 118.214 1.64
+GLX XE1 CD XE2 123.571 1.50
 
 loop_
 _chem_comp_tor.comp_id
@@ -114,11 +139,11 @@ _chem_comp_tor.atom_id_4
 _chem_comp_tor.value_angle
 _chem_comp_tor.value_angle_esd
 _chem_comp_tor.period
-GLX chi1      N   CA CB CG  -60.000 10.0 3
-GLX chi2      CA  CB CG CD  180.000 10.0 3
-GLX sp3_sp3_1 C   CA N  H   180.000 10.0 3
-GLX sp2_sp3_7 XE1 CD CG HG1 0.000   10.0 6
-GLX sp2_sp3_1 O   C  CA N   0.000   10.0 6
+GLX chi1 N CA CB CG -60.000 10.0 3
+GLX chi2 CA CB CG CD 180.000 10.0 3
+GLX chi3 CB CG CD XE1 60.000 10.0 6
+GLX sp3_sp3_1 C CA N H 180.000 10.0 3
+GLX sp2_sp3_1 O C CA N 0.000 10.0 6
 
 loop_
 _chem_comp_chir.comp_id
@@ -135,12 +160,12 @@ _chem_comp_plane_atom.comp_id
 _chem_comp_plane_atom.plane_id
 _chem_comp_plane_atom.atom_id
 _chem_comp_plane_atom.dist_esd
-GLX plan-1 C   0.020
-GLX plan-1 CA  0.020
-GLX plan-1 O   0.020
+GLX plan-1 C 0.020
+GLX plan-1 CA 0.020
+GLX plan-1 O 0.020
 GLX plan-1 OXT 0.020
-GLX plan-2 CD  0.020
-GLX plan-2 CG  0.020
+GLX plan-2 CD 0.020
+GLX plan-2 CG 0.020
 GLX plan-2 XE1 0.020
 GLX plan-2 XE2 0.020
 
@@ -150,18 +175,20 @@ _pdbx_chem_comp_descriptor.type
 _pdbx_chem_comp_descriptor.program
 _pdbx_chem_comp_descriptor.program_version
 _pdbx_chem_comp_descriptor.descriptor
-GLX INCHI            InChi                1     "InChI=C(CCC(N)C=O)([X])[X]"
-GLX SMILES_CANONICAL CACTVS               3.370 "C(CC[C@H](N)C(O)=O)(=[F,Cl,Br,I])[F,Cl,Br,I]"
-GLX SMILES           CACTVS               3.370 "C(CC[CH](N)C(O)=O)(=[F,Cl,Br,I])[F,Cl,Br,I]"
-GLX SMILES_CANONICAL "OpenEye OEToolkits" 1.7.2 "*=C(*)CC[C@@H](C(=O)O)N"
-GLX SMILES           "OpenEye OEToolkits" 1.7.2 "*=C(*)CCC(C(=O)O)N"
+GLX SMILES ACDLabs 12.01 O=C(O)C(N)CCC(=O)O
+GLX SMILES_CANONICAL CACTVS 3.370 N[C@@H](CCC(O)=O)C(O)=O
+GLX SMILES CACTVS 3.370 N[CH](CCC(O)=O)C(O)=O
+GLX SMILES_CANONICAL "OpenEye OEToolkits" 1.7.0 C(CC(=O)O)[C@@H](C(=O)O)N
+GLX SMILES "OpenEye OEToolkits" 1.7.0 C(CC(=O)O)C(C(=O)O)N
+GLX InChI InChI 1.03 InChI=1S/C5H9NO4/c6-3(5(9)10)1-2-4(7)8/h3H,1-2,6H2,(H,7,8)(H,9,10)/t3-/m0/s1
+GLX InChIKey InChI 1.03 WHUUTDBJXJRKMK-VKHMYHEASA-N
 
 loop_
 _pdbx_chem_comp_description_generator.comp_id
 _pdbx_chem_comp_description_generator.program_name
 _pdbx_chem_comp_description_generator.program_version
 _pdbx_chem_comp_description_generator.descriptor
-GLX acedrg          270       "dictionary generator"
-GLX acedrg_database 12        "data source"
-GLX rdkit           2019.09.1 "Chemoinformatics tool"
-GLX refmac5         5.8.0403  "optimization tool"
+GLX acedrg 243 "dictionary generator"
+GLX acedrg_database 11 "data source"
+GLX rdkit 2017.03.2 "Chemoinformatics tool"
+GLX refmac5 5.8.0238 "optimization tool"

--- a/g/GLX.cif
+++ b/g/GLX.cif
@@ -1,11 +1,3 @@
-global_
-_lib_name         ?
-_lib_version      ?
-_lib_update       ?
-# ------------------------------------------------
-#
-# ---   LIST OF MONOMERS ---
-#
 data_comp_list
 loop_
 _chem_comp.id
@@ -15,97 +7,65 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-GLX      GLX 'GLU/GLN AMBIGUOUS                   ' peptide            20  10 .
-# ------------------------------------------------------
-# ------------------------------------------------------
-#
-# --- DESCRIPTION OF MONOMERS ---
-#
+GLX GLX "GLU/GLN AMBIGUOUS" peptide 21 10 .
+
 data_comp_GLX
-#
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
-_chem_comp_atom.partial_charge
+_chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
- GLX           N      N    NH1      -1.000      0.000    0.000    0.000
- GLX           H      H    HNH1      0.000     -0.572    0.062    0.769
- GLX           CA     C    CH1       0.000      1.035    1.071    0.062
- GLX           HA     H    H         0.000      1.540    0.965    0.896
- GLX           CB     C    CH2       0.000      1.989    0.907   -1.095
- GLX           HB1    H    H         0.000      1.481    0.986   -1.918
- GLX           HB2    H    H         0.000      2.379    0.021   -1.042
- GLX           CG     C    CH2       0.000      3.083    1.941   -1.077
- GLX           HG1    H    H         0.000      3.603    1.845   -0.264
- GLX           HG2    H    H         0.000      2.688    2.827   -1.105
- GLX           CD     C    C         0.000      3.978    1.752   -2.273
- GLX           XE1    N    NH2       0.000      3.800    0.755   -3.315
- GLX           HE11   H    H         0.000      3.108    0.032   -3.375
- GLX           HE12   H    H         0.000      4.449    0.718   -4.089
- GLX           XE2    N    NH2       0.000      5.071    2.701   -2.464
- GLX           HE21   H    H         0.000      5.299    3.458   -1.830
- GLX           HE22   H    H         0.000      5.698    2.627   -3.256
- GLX           C      C    C         0.000      0.359    2.442    0.081
- GLX           O      O    OC       -0.500     -0.760    2.667   -0.392
- GLX           OXT    O    OC       -0.500      0.855    3.388    0.705
-loop_
-_chem_comp_tree.comp_id
-_chem_comp_tree.atom_id
-_chem_comp_tree.atom_back
-_chem_comp_tree.atom_forward
-_chem_comp_tree.connect_type
- GLX      N      n/a    CA     START
- GLX      H      N      .      .
- GLX      CA     N      C      .
- GLX      HA     CA     .      .
- GLX      CB     CA     CG     .
- GLX      HB1    CB     .      .
- GLX      HB2    CB     .      .
- GLX      CG     CB     CD     .
- GLX      HG1    CG     .      .
- GLX      HG2    CG     .      .
- GLX      CD     CG     XE2    .
- GLX      XE1    CD     HE12   .
- GLX      HE11   XE1    .      .
- GLX      HE12   XE1    .      .
- GLX      XE2    CD     HE22   .
- GLX      HE21   XE2    .      .
- GLX      HE22   XE2    .      .
- GLX      C      CA     OXT    .
- GLX      O      C      .      .
- GLX      OXT    C      .      END
+GLX N   N NT3 1  -0.090 1.866  0.638
+GLX CA  C CH1 0  0.098  0.409  0.405
+GLX C   C C   0  1.472  0.174  -0.247
+GLX O   O O   0  1.672  0.704  -1.362
+GLX CB  C CH2 0  -1.031 -0.145 -0.466
+GLX CG  C CH2 0  -2.352 -0.317 0.278
+GLX CD  C C   0  -3.385 -1.079 -0.507
+GLX XE1 N NH1 0  -3.779 -2.254 -0.125
+GLX XE2 N NH2 0  -3.847 -0.454 -1.600
+GLX OXT O OC  -1 2.290  -0.531 0.384
+GLX H   H H   0  -0.877 2.016  1.051
+GLX H2  H H   0  -0.084 2.307  -0.149
+GLX H3  H H   0  0.574  2.186  1.158
+GLX HA  H H   0  0.082  -0.051 1.283
+GLX HB1 H H   0  -0.756 -1.015 -0.827
+GLX HB2 H H   0  -1.170 0.461  -1.224
+GLX HG1 H H   0  -2.712 0.576  0.499
+GLX HG2 H H   0  -2.181 -0.793 1.127
+
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
 _chem_comp_bond.type
+_chem_comp_bond.aromatic
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-GLX       N         CA        single    1.491     0.021     1.491     0.021     
-GLX       CA        HA        single    1.089     0.010     0.989     0.005     
-GLX       CA        CB        single    1.530     0.020     1.530     0.020     
-GLX       CB        HB1       single    1.089     0.010     0.989     0.005     
-GLX       CB        HB2       single    1.089     0.010     0.989     0.005     
-GLX       CB        CG        single    1.520     0.020     1.520     0.020     
-GLX       CG        HG1       single    1.089     0.010     0.989     0.005     
-GLX       CG        HG2       single    1.089     0.010     0.989     0.005     
-GLX       CG        CD        single    1.516     0.020     1.516     0.020     
-GLX       XE1       CD        single    1.450     0.020     1.450     0.020     
-GLX       XE2       CD        single    1.450     0.020     1.450     0.020     
-GLX       HE11      XE1       single    1.016     0.010     0.899     0.007     
-GLX       HE12      XE1       single    1.016     0.010     0.899     0.007     
-GLX       HE21      XE2       single    1.016     0.010     0.899     0.007     
-GLX       HE22      XE2       single    1.016     0.010     0.899     0.007     
-GLX       CA        C         single    1.525     0.021     1.525     0.021     
-GLX       C         O         deloc     1.231     0.020     1.231     0.020     
-GLX       N         H         single    1.016     0.010     0.899     0.007     
-GLX       C         OXT       deloc     1.231     0.020     1.231     0.020     
+GLX N  CA  SINGLE n 1.487 0.0100 1.487 0.0100
+GLX CA C   SINGLE n 1.538 0.0113 1.538 0.0113
+GLX CA CB  SINGLE n 1.529 0.0100 1.529 0.0100
+GLX C  O   DOUBLE n 1.251 0.0183 1.251 0.0183
+GLX C  OXT SINGLE n 1.251 0.0183 1.251 0.0183
+GLX CB CG  SINGLE n 1.526 0.0100 1.526 0.0100
+GLX CG CD  SINGLE n 1.504 0.0100 1.504 0.0100
+GLX CD XE1 DOUBLE n 1.297 0.0200 1.297 0.0200
+GLX CD XE2 SINGLE n 1.338 0.0163 1.338 0.0163
+GLX N  H   SINGLE n 1.036 0.0160 0.902 0.0102
+GLX N  H2  SINGLE n 1.036 0.0160 0.902 0.0102
+GLX N  H3  SINGLE n 1.036 0.0160 0.902 0.0102
+GLX CA HA  SINGLE n 1.089 0.0100 0.991 0.0200
+GLX CB HB1 SINGLE n 1.089 0.0100 0.980 0.0168
+GLX CB HB2 SINGLE n 1.089 0.0100 0.980 0.0168
+GLX CG HG1 SINGLE n 1.089 0.0100 0.988 0.0100
+GLX CG HG2 SINGLE n 1.089 0.0100 0.988 0.0100
+
 loop_
 _chem_comp_angle.comp_id
 _chem_comp_angle.atom_id_1
@@ -113,37 +73,37 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
- GLX      O      C      CA      121.000    3.000
- GLX      C      CA     HA      108.810    3.000
- GLX      C      CA     N       109.470    3.000
- GLX      C      CA     CB      109.470    3.000
- GLX      HA     CA     N       109.470    3.000
- GLX      HA     CA     CB      108.340    3.000
- GLX      N      CA     CB      109.470    3.000
- GLX      CA     CB     HB1     109.470    3.000
- GLX      CA     CB     HB2     109.470    3.000
- GLX      CA     CB     CG      111.000    3.000
- GLX      HB1    CB     HB2     107.900    3.000
- GLX      HB1    CB     CG      109.470    3.000
- GLX      HB2    CB     CG      109.470    3.000
- GLX      CB     CG     HG1     109.470    3.000
- GLX      CB     CG     HG2     109.470    3.000
- GLX      CB     CG     CD      111.000    3.000
- GLX      HG1    CG     HG2     107.900    3.000
- GLX      HG1    CG     CD      109.470    3.000
- GLX      HG2    CG     CD      109.470    3.000
- GLX      CG     CD     XE2     120.000    3.000
- GLX      CG     CD     XE1     120.000    3.000
- GLX      XE2    CD     XE1     120.000    3.000
- GLX      CD     XE2    HE22    120.000    3.000
- GLX      CD     XE2    HE21    120.000    3.000
- GLX      HE22   XE2    HE21    120.000    3.000
- GLX      CD     XE1    HE12    120.000    3.000
- GLX      CD     XE1    HE11    120.000    3.000
- GLX      HE12   XE1    HE11    120.000    3.000
- GLX      H      N      CA      109.470    3.000
- GLX      CA     C      OXT     121.000    3.000
- GLX      O      C      OXT     118.000    3.000
+GLX CA  N  H   109.990 3.00
+GLX CA  N  H2  109.990 3.00
+GLX CA  N  H3  109.990 3.00
+GLX H   N  H2  109.032 3.00
+GLX H   N  H3  109.032 3.00
+GLX H2  N  H3  109.032 3.00
+GLX N   CA C   109.258 1.50
+GLX N   CA CB  110.440 2.46
+GLX N   CA HA  108.387 1.58
+GLX C   CA CB  111.059 3.00
+GLX C   CA HA  108.774 1.79
+GLX CB  CA HA  109.080 2.33
+GLX CA  C  O   117.148 1.60
+GLX CA  C  OXT 117.148 1.60
+GLX O   C  OXT 125.704 1.50
+GLX CA  CB CG  113.457 1.50
+GLX CA  CB HB1 108.677 1.74
+GLX CA  CB HB2 108.677 1.74
+GLX CG  CB HB1 108.873 1.50
+GLX CG  CB HB2 108.873 1.50
+GLX HB1 CB HB2 107.655 1.50
+GLX CB  CG CD  113.605 3.00
+GLX CB  CG HG1 108.870 1.50
+GLX CB  CG HG2 108.870 1.50
+GLX CD  CG HG1 108.942 1.50
+GLX CD  CG HG2 108.942 1.50
+GLX HG1 CG HG2 107.856 1.50
+GLX CG  CD XE1 121.049 3.00
+GLX CG  CD XE2 114.843 1.50
+GLX XE1 CD XE2 124.109 3.00
+
 loop_
 _chem_comp_tor.comp_id
 _chem_comp_tor.id
@@ -154,12 +114,12 @@ _chem_comp_tor.atom_id_4
 _chem_comp_tor.value_angle
 _chem_comp_tor.value_angle_esd
 _chem_comp_tor.period
- GLX      chi1             N      CA     CB     CG               180.000           15.000   3
- GLX      chi2             CA     CB     CG     CD               180.000           15.000   3
- GLX      chi3             CB     CG     CD     XE1                0.000           30.000   2
- GLX      hh2              CG     CD     XE2    HE21               0.000           30.000   2
- GLX      hh1              CG     CD     XE1    HE11               0.000           30.000   2
- GLX      psi              N      CA     C      OXT              160.000           30.000   2
+GLX chi1      N   CA CB CG  -60.000 10.0 3
+GLX chi2      CA  CB CG CD  180.000 10.0 3
+GLX sp3_sp3_1 C   CA N  H   180.000 10.0 3
+GLX sp2_sp3_7 XE1 CD CG HG1 0.000   10.0 6
+GLX sp2_sp3_1 O   C  CA N   0.000   10.0 6
+
 loop_
 _chem_comp_chir.comp_id
 _chem_comp_chir.id
@@ -168,26 +128,40 @@ _chem_comp_chir.atom_id_1
 _chem_comp_chir.atom_id_2
 _chem_comp_chir.atom_id_3
 _chem_comp_chir.volume_sign
- GLX      chir_01          CA     N      CB     C         negativ
+GLX chir_1 CA N C CB positive
+
 loop_
 _chem_comp_plane_atom.comp_id
 _chem_comp_plane_atom.plane_id
 _chem_comp_plane_atom.atom_id
 _chem_comp_plane_atom.dist_esd
- GLX      plan-2            CG        0.020
- GLX      plan-2            CD        0.020
- GLX      plan-2            XE1       0.020
- GLX      plan-2            XE2       0.020
- GLX      plan-3            XE1       0.020
- GLX      plan-3            CD        0.020
- GLX      plan-3            HE11      0.020
- GLX      plan-3            HE12      0.020
- GLX      plan-4            XE2       0.020
- GLX      plan-4            CD        0.020
- GLX      plan-4            HE21      0.020
- GLX      plan-4            HE22      0.020
- GLX      oxt               C         0.020
- GLX      oxt               CA        0.020
- GLX      oxt               O         0.020
- GLX      oxt               OXT       0.020
-# ------------------------------------------------------
+GLX plan-1 C   0.020
+GLX plan-1 CA  0.020
+GLX plan-1 O   0.020
+GLX plan-1 OXT 0.020
+GLX plan-2 CD  0.020
+GLX plan-2 CG  0.020
+GLX plan-2 XE1 0.020
+GLX plan-2 XE2 0.020
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+GLX INCHI            InChi                1     "InChI=C(CCC(N)C=O)([X])[X]"
+GLX SMILES_CANONICAL CACTVS               3.370 "C(CC[C@H](N)C(O)=O)(=[F,Cl,Br,I])[F,Cl,Br,I]"
+GLX SMILES           CACTVS               3.370 "C(CC[CH](N)C(O)=O)(=[F,Cl,Br,I])[F,Cl,Br,I]"
+GLX SMILES_CANONICAL "OpenEye OEToolkits" 1.7.2 "*=C(*)CC[C@@H](C(=O)O)N"
+GLX SMILES           "OpenEye OEToolkits" 1.7.2 "*=C(*)CCC(C(=O)O)N"
+
+loop_
+_pdbx_chem_comp_description_generator.comp_id
+_pdbx_chem_comp_description_generator.program_name
+_pdbx_chem_comp_description_generator.program_version
+_pdbx_chem_comp_description_generator.descriptor
+GLX acedrg          270       "dictionary generator"
+GLX acedrg_database 12        "data source"
+GLX rdkit           2019.09.1 "Chemoinformatics tool"
+GLX refmac5         5.8.0403  "optimization tool"


### PR DESCRIPTION
Most importantly, energy type of N in ASX was N1, which does not exist in ener_lib.

```sh
wget https://files.rcsb.org/ligands/download/ASX.cif
sed -e "s/\<X\>/N/" ASX.cif > ASX_as_N.cif
acedrg -c ASX_as_N.cif
sed -e "/\<H4\>/d; /\<H5\>/d; /\<H6\>/d" AcedrgOut.cif > AcedrgOut_delH456.cif
```
and deleted plan-3 (only two atoms remained).