### PR TITLE
fix zero degree angles

### DIFF
--- a/d/D65.cif
+++ b/d/D65.cif
@@ -8,7 +8,7 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-D65     D65      2-(1,1-difluoroethyl)-5-methyl-N-[4-(pentafluoro-lambda~6~-sulfanyl)phenyl][1,2,4]triazolo[1,5-a]pyrimidin-7-amine     NON-POLYMER     39     27     .     
+D65     D65      "2-(1,1-difluoroethyl)-5-methyl-N-[4-(pentafluoro-lambda~6~-sulfanyl)phenyl][1,2,4]triazolo[1,5-a]pyrimidin-7-amine"     NON-POLYMER     39     27     .     
 #
 data_comp_D65
 #
@@ -21,45 +21,88 @@ _chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-D65     F7      F       F       0       -30.340     -9.658      -14.495     
-D65     S1      S       S       0       -30.714     -9.302      -12.997     
-D65     F4      F       F       0       -30.340     -9.658      -14.495     
-D65     F5      F       F       0       -30.340     -9.658      -14.495     
-D65     F3      F       F       0       -30.340     -9.658      -14.495     
-D65     F6      F       F       0       -30.340     -9.658      -14.495     
-D65     C5      C       CR6     0       -29.335     -9.773      -14.141     
-D65     C4      C       CR16    0       -28.415     -8.780      -14.595     
-D65     C3      C       CR16    0       -27.322     -9.135      -15.364     
-D65     C6      C       CR16    0       -28.841     -11.113     -14.146     
-D65     C1      C       CR16    0       -27.744     -11.452     -14.918     
-D65     C2      C       CR6     0       -26.964     -10.468     -15.509     
-D65     N1      N       NH1     0       -25.824     -10.828     -16.276     
-D65     C7      C       CR6     0       -25.795     -11.697     -17.314     
-D65     C8      C       CR16    0       -26.834     -11.778     -18.255     
-D65     C9      C       CR6     0       -26.740     -12.712     -19.311     
-D65     C10     C       CH3     0       -27.829     -12.825     -20.333     
-D65     N2      N       NT      0       -24.732     -12.562     -17.499     
-D65     C11     C       CR56    0       -24.680     -13.447     -18.532     
-D65     N5      N       NRD6    0       -25.661     -13.578     -19.488     
-D65     N3      N       NRD5    0       -23.627     -12.664     -16.726     
-D65     C12     C       CR5     0       -22.925     -13.643     -17.345     
-D65     N4      N       NRD5    0       -23.544     -14.144     -18.456     
-D65     C13     C       CT      0       -21.610     -14.120     -16.856     
-D65     F1      F       F       0       -20.748     -13.102     -16.635     
-D65     F2      F       F       0       -21.019     -14.980     -17.716     
-D65     C14     C       CH3     0       -21.761     -14.855     -15.539     
-D65     H1      H       H       0       -28.636     -7.846      -14.539     
-D65     H2      H       H       0       -26.796     -8.467      -15.769     
-D65     H3      H       H       0       -29.362     -11.829     -13.774     
-D65     H4      H       H       0       -27.505     -12.357     -15.021     
-D65     H5      H       H       0       -25.062     -10.449     -16.055     
-D65     H6      H       H       0       -27.589     -11.219     -18.190     
-D65     H7      H       H       0       -28.684     -12.643     -19.915     
-D65     H8      H       H       0       -27.837     -13.720     -20.704     
-D65     H9      H       H       0       -27.675     -12.184     -21.042     
-D65     H10     H       H       0       -22.192     -14.274     -14.889     
-D65     H11     H       H       0       -20.883     -15.114     -15.209     
-D65     H12     H       H       0       -22.303     -15.652     -15.672     
+D65     F7      F       F       0       -30.971     -9.532      -12.293     
+D65     S1      S       S       0       -30.807     -8.337      -13.319     
+D65     F4      F       F       0       -30.707     -7.107      -14.311     
+D65     F5      F       F       0       -32.072     -7.651      -12.659     
+D65     F3      F       F       0       -31.777     -9.046      -14.350     
+D65     F6      F       F       0       -29.899     -7.594      -12.255     
+D65     C5      C       CR6     0       -29.357     -9.124      -14.074     
+D65     C4      C       CR16    0       -28.220     -8.369      -14.347     
+D65     C3      C       CR16    0       -27.116     -8.974      -14.924     
+D65     C6      C       CR16    0       -29.383     -10.481     -14.380     
+D65     C1      C       CR16    0       -28.273     -11.077     -14.956     
+D65     C2      C       CR6     0       -27.129     -10.332     -15.237     
+D65     N1      N       NH1     0       -25.994     -10.927     -15.821     
+D65     C7      C       CR6     0       -25.921     -11.769     -16.945     
+D65     C8      C       CR16    0       -26.940     -11.945     -17.892     
+D65     C9      C       CR6     0       -26.751     -12.816     -18.979     
+D65     C10     C       CH3     0       -27.837     -13.009     -19.993     
+D65     N2      N       NR5     0       -24.769     -12.500     -17.177     
+D65     C11     C       CR56    0       -24.638     -13.340     -18.260     
+D65     N5      N       NRD6    0       -25.619     -13.504     -19.162     
+D65     N3      N       NRD5    0       -23.611     -12.544     -16.444     
+D65     C12     C       CR5     0       -22.838     -13.414     -17.130     
+D65     N4      N       NRD5    0       -23.436     -13.890     -18.204     
+D65     C13     C       CT      0       -21.453     -13.806     -16.729     
+D65     F1      F       F       0       -21.067     -13.145     -15.600     
+D65     F2      F       F       0       -20.563     -13.495     -17.712     
+D65     C14     C       CH3     0       -21.296     -15.279     -16.448     
+D65     H1      H       H       0       -28.192     -7.442      -14.142     
+D65     H2      H       H       0       -26.344     -8.462      -15.109     
+D65     H3      H       H       0       -30.154     -11.005     -14.198     
+D65     H4      H       H       0       -28.290     -11.998     -15.165     
+D65     H5      H       H       0       -25.234     -10.746     -15.429     
+D65     H6      H       H       0       -27.762     -11.478     -17.803     
+D65     H7      H       H       0       -28.694     -12.788     -19.598     
+D65     H8      H       H       0       -27.848     -13.932     -20.286     
+D65     H9      H       H       0       -27.676     -12.431     -20.754     
+D65     H10     H       H       0       -21.916     -15.545     -15.746     
+D65     H11     H       H       0       -20.384     -15.460     -16.159     
+D65     H12     H       H       0       -21.486     -15.787     -17.257     
+loop_
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+D65    F7    F(SC[6a]F4)
+D65    S1    S(C[6a]C[6a]2)(F)5
+D65    F4    F(SC[6a]F4)
+D65    F5    F(SC[6a]F4)
+D65    F3    F(SC[6a]F4)
+D65    F6    F(SC[6a]F4)
+D65    C5    C[6a](C[6a]C[6a]H)2(SF5){1|C<3>,2|H<1>}
+D65    C4    C[6a](C[6a]C[6a]H)(C[6a]C[6a]S)(H){1|C<3>,1|H<1>,1|N<3>}
+D65    C3    C[6a](C[6a]C[6a]H)(C[6a]C[6a]N)(H){1|C<3>,1|H<1>,1|S<6>}
+D65    C6    C[6a](C[6a]C[6a]H)(C[6a]C[6a]S)(H){1|C<3>,1|H<1>,1|N<3>}
+D65    C1    C[6a](C[6a]C[6a]H)(C[6a]C[6a]N)(H){1|C<3>,1|H<1>,1|S<6>}
+D65    C2    C[6a](C[6a]C[6a]H)2(NC[6a]H){1|C<3>,2|H<1>}
+D65    N1    N(C[6a]N[5a,6a]C[6a])(C[6a]C[6a]2)(H)
+D65    C7    C[6a](N[5a,6a]C[5a,6a]N[5a])(C[6a]C[6a]H)(NC[6a]H){1|C<3>,1|C<4>,2|N<2>}
+D65    C8    C[6a](C[6a]N[5a,6a]N)(C[6a]N[6a]C)(H){1|C<3>,1|N<2>}
+D65    C9    C[6a](N[6a]C[5a,6a])(C[6a]C[6a]H)(CH3){1|N<2>,2|N<3>}
+D65   C10    C(C[6a]C[6a]N[6a])(H)3
+D65    N2    N[5a,6a](C[5a,6a]N[5a]N[6a])(C[6a]C[6a]N)(N[5a]C[5a]){1|C<3>,1|C<4>,1|H<1>}
+D65   C11    C[5a,6a](N[5a,6a]C[6a]N[5a])(N[5a]C[5a])(N[6a]C[6a]){1|C<3>,1|N<3>,2|C<4>}
+D65    N5    N[6a](C[5a,6a]N[5a,6a]N[5a])(C[6a]C[6a]C){1|H<1>,1|N<2>,2|C<3>}
+D65    N3    N[5a](N[5a,6a]C[5a,6a]C[6a])(C[5a]N[5a]C){1|C<3>,1|N<2>,1|N<3>}
+D65   C12    C[5a](N[5a]C[5a,6a])(N[5a]N[5a,6a])(CCFF){1|C<3>,1|N<2>}
+D65    N4    N[5a](C[5a,6a]N[5a,6a]N[6a])(C[5a]N[5a]C){2|C<3>}
+D65   C13    C(C[5a]N[5a]2)(CH3)(F)2
+D65    F1    F(CC[5a]CF)
+D65    F2    F(CC[5a]CF)
+D65   C14    C(CC[5a]FF)(H)3
+D65    H1    H(C[6a]C[6a]2)
+D65    H2    H(C[6a]C[6a]2)
+D65    H3    H(C[6a]C[6a]2)
+D65    H4    H(C[6a]C[6a]2)
+D65    H5    H(NC[6a]2)
+D65    H6    H(C[6a]C[6a]2)
+D65    H7    H(CC[6a]HH)
+D65    H8    H(CC[6a]HH)
+D65    H9    H(CC[6a]HH)
+D65   H10    H(CCHH)
+D65   H11    H(CCHH)
+D65   H12    H(CCHH)
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
@@ -70,47 +113,47 @@ _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-D65          C9         C10      SINGLE       n     1.497  0.0100     1.497  0.0100
-D65          C9          N5      DOUBLE       y     1.373  0.0200     1.373  0.0200
-D65         C11          N5      SINGLE       y     1.355  0.0200     1.355  0.0200
-D65          C8          C9      SINGLE       y     1.410  0.0100     1.410  0.0100
-D65         C11          N4      DOUBLE       y     1.333  0.0200     1.333  0.0200
-D65          N2         C11      SINGLE       y     1.368  0.0160     1.368  0.0160
-D65         C12          N4      SINGLE       y     1.341  0.0200     1.341  0.0200
-D65          C7          C8      DOUBLE       y     1.398  0.0160     1.398  0.0160
-D65         C13          F2      SINGLE       n     1.352  0.0100     1.352  0.0100
-D65          C7          N2      SINGLE       y     1.379  0.0122     1.379  0.0122
-D65          N2          N3      SINGLE       y     1.366  0.0181     1.366  0.0181
-D65         C12         C13      SINGLE       n     1.481  0.0100     1.481  0.0100
-D65          N3         C12      DOUBLE       y     1.341  0.0200     1.341  0.0200
-D65          N1          C7      SINGLE       n     1.350  0.0162     1.350  0.0162
-D65         C13         C14      SINGLE       n     1.516  0.0200     1.516  0.0200
-D65         C13          F1      SINGLE       n     1.352  0.0100     1.352  0.0100
-D65          C2          N1      SINGLE       n     1.420  0.0100     1.420  0.0100
-D65          C1          C2      DOUBLE       y     1.386  0.0100     1.386  0.0100
-D65          C3          C2      SINGLE       y     1.386  0.0100     1.386  0.0100
-D65          C6          C1      SINGLE       y     1.380  0.0100     1.380  0.0100
-D65          C4          C3      DOUBLE       y     1.380  0.0100     1.380  0.0100
-D65          S1          F3      SINGLE       n     1.587  0.0100     1.587  0.0100
-D65          C5          C6      DOUBLE       y     1.383  0.0100     1.383  0.0100
-D65          C5          C4      SINGLE       y     1.383  0.0100     1.383  0.0100
-D65          S1          C5      SINGLE       n     1.803  0.0100     1.803  0.0100
-D65          S1          F4      SINGLE       n     1.587  0.0100     1.587  0.0100
-D65          F7          S1      SINGLE       n     1.587  0.0100     1.587  0.0100
-D65          S1          F5      SINGLE       n     1.587  0.0100     1.587  0.0100
-D65          S1          F6      SINGLE       n     1.587  0.0100     1.587  0.0100
-D65          C4          H1      SINGLE       n     1.082  0.0130     0.941  0.0197
-D65          C3          H2      SINGLE       n     1.082  0.0130     0.942  0.0186
-D65          C6          H3      SINGLE       n     1.082  0.0130     0.941  0.0197
-D65          C1          H4      SINGLE       n     1.082  0.0130     0.942  0.0186
-D65          N1          H5      SINGLE       n     1.016  0.0100     0.879  0.0200
-D65          C8          H6      SINGLE       n     1.082  0.0130     0.941  0.0156
-D65         C10          H7      SINGLE       n     1.089  0.0100     0.969  0.0130
-D65         C10          H8      SINGLE       n     1.089  0.0100     0.969  0.0130
-D65         C10          H9      SINGLE       n     1.089  0.0100     0.969  0.0130
-D65         C14         H10      SINGLE       n     1.089  0.0100     0.973  0.0141
-D65         C14         H11      SINGLE       n     1.089  0.0100     0.973  0.0141
-D65         C14         H12      SINGLE       n     1.089  0.0100     0.973  0.0141
+D65          C9         C10      SINGLE       n     1.498  0.0100     1.498  0.0100
+D65          C9          N5      DOUBLE       y     1.331  0.0100     1.331  0.0100
+D65         C11          N5      SINGLE       y     1.339  0.0100     1.339  0.0100
+D65          C8          C9      SINGLE       y     1.388  0.0200     1.388  0.0200
+D65         C11          N4      DOUBLE       y     1.324  0.0100     1.324  0.0100
+D65          N2         C11      SINGLE       y     1.377  0.0100     1.377  0.0100
+D65         C12          N4      SINGLE       y     1.307  0.0200     1.307  0.0200
+D65          C7          C8      DOUBLE       y     1.396  0.0132     1.396  0.0132
+D65         C13          F2      SINGLE       n     1.362  0.0200     1.362  0.0200
+D65          C7          N2      SINGLE       y     1.380  0.0144     1.380  0.0144
+D65          N2          N3      SINGLE       y     1.373  0.0100     1.373  0.0100
+D65         C12         C13      SINGLE       n     1.493  0.0133     1.493  0.0133
+D65          N3         C12      DOUBLE       y     1.338  0.0200     1.338  0.0200
+D65          N1          C7      SINGLE       n     1.400  0.0200     1.400  0.0200
+D65         C13         C14      SINGLE       n     1.508  0.0200     1.508  0.0200
+D65         C13          F1      SINGLE       n     1.362  0.0200     1.362  0.0200
+D65          C2          N1      SINGLE       n     1.406  0.0137     1.406  0.0137
+D65          C1          C2      DOUBLE       y     1.390  0.0108     1.390  0.0108
+D65          C3          C2      SINGLE       y     1.390  0.0108     1.390  0.0108
+D65          C6          C1      SINGLE       y     1.382  0.0100     1.382  0.0100
+D65          C4          C3      DOUBLE       y     1.382  0.0100     1.382  0.0100
+D65          S1          F3      SINGLE       n     1.583  0.0100     1.583  0.0100
+D65          C5          C6      DOUBLE       y     1.385  0.0100     1.385  0.0100
+D65          C5          C4      SINGLE       y     1.385  0.0100     1.385  0.0100
+D65          S1          C5      SINGLE       n     1.806  0.0109     1.806  0.0109
+D65          S1          F4      SINGLE       n     1.583  0.0100     1.583  0.0100
+D65          F7          S1      SINGLE       n     1.583  0.0100     1.583  0.0100
+D65          S1          F5      SINGLE       n     1.583  0.0100     1.583  0.0100
+D65          S1          F6      SINGLE       n     1.583  0.0100     1.583  0.0100
+D65          C4          H1      SINGLE       n     1.082  0.0130     0.950  0.0100
+D65          C3          H2      SINGLE       n     1.082  0.0130     0.945  0.0100
+D65          C6          H3      SINGLE       n     1.082  0.0130     0.950  0.0100
+D65          C1          H4      SINGLE       n     1.082  0.0130     0.945  0.0100
+D65          N1          H5      SINGLE       n     1.016  0.0100     0.874  0.0200
+D65          C8          H6      SINGLE       n     1.082  0.0130     0.950  0.0100
+D65         C10          H7      SINGLE       n     1.089  0.0100     0.969  0.0191
+D65         C10          H8      SINGLE       n     1.089  0.0100     0.969  0.0191
+D65         C10          H9      SINGLE       n     1.089  0.0100     0.969  0.0191
+D65         C14         H10      SINGLE       n     1.089  0.0100     0.974  0.0137
+D65         C14         H11      SINGLE       n     1.089  0.0100     0.974  0.0137
+D65         C14         H12      SINGLE       n     1.089  0.0100     0.974  0.0137
 loop_
 _chem_comp_angle.comp_id
 _chem_comp_angle.atom_id_1
@@ -118,81 +161,81 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-D65          F3          S1          C5       0.000    3.00
-D65          F3          S1          F4       0.000    3.00
-D65          F3          S1          F7       0.000    3.00
-D65          F3          S1          F5       0.000    3.00
-D65          F3          S1          F6       0.000    3.00
-D65          C5          S1          F4       0.000    3.00
-D65          C5          S1          F7       0.000    3.00
-D65          C5          S1          F5       0.000    3.00
-D65          C5          S1          F6       0.000    3.00
-D65          F4          S1          F7       0.000    3.00
-D65          F4          S1          F5       0.000    3.00
-D65          F4          S1          F6       0.000    3.00
-D65          F7          S1          F5       0.000    3.00
-D65          F7          S1          F6       0.000    3.00
-D65          F5          S1          F6       0.000    3.00
-D65          C6          C5          C4     120.172    1.50
-D65          C6          C5          S1     119.914    1.50
-D65          C4          C5          S1     119.914    1.50
-D65          C3          C4          C5     120.290    1.50
-D65          C3          C4          H1     119.612    1.50
-D65          C5          C4          H1     120.098    1.50
-D65          C2          C3          C4     120.008    1.50
-D65          C2          C3          H2     119.849    1.50
-D65          C4          C3          H2     120.143    1.50
-D65          C1          C6          C5     120.290    1.50
-D65          C1          C6          H3     119.612    1.50
-D65          C5          C6          H3     120.098    1.50
-D65          C2          C1          C6     120.008    1.50
-D65          C2          C1          H4     119.849    1.50
-D65          C6          C1          H4     120.143    1.50
-D65          N1          C2          C1     120.383    2.62
-D65          N1          C2          C3     120.383    2.62
-D65          C1          C2          C3     119.233    1.50
-D65          C7          N1          C2     126.474    2.64
-D65          C7          N1          H5     116.767    2.17
-D65          C2          N1          H5     116.759    2.79
-D65          C8          C7          N2     119.615    3.00
-D65          C8          C7          N1     120.770    3.00
-D65          N2          C7          N1     119.615    3.00
-D65          C9          C8          C7     119.650    1.50
-D65          C9          C8          H6     119.793    1.50
-D65          C7          C8          H6     120.557    1.50
-D65         C10          C9          N5     115.341    2.80
-D65         C10          C9          C8     121.203    1.50
-D65          N5          C9          C8     123.456    1.50
-D65          C9         C10          H7     109.485    1.50
-D65          C9         C10          H8     109.485    1.50
-D65          C9         C10          H9     109.485    1.50
-D65          H7         C10          H8     109.380    1.50
-D65          H7         C10          H9     109.380    1.50
-D65          H8         C10          H9     109.380    1.50
-D65         C11          N2          C7     109.471    3.00
-D65         C11          N2          N3     111.210    1.50
-D65          C7          N2          N3     109.471    3.00
-D65          N5         C11          N4     125.699    1.50
-D65          N5         C11          N2     122.836    1.50
-D65          N4         C11          N2     111.465    1.50
-D65          C9          N5         C11     112.140    1.50
-D65          N2          N3         C12     104.585    1.50
-D65          N4         C12         C13     123.421    3.00
-D65          N4         C12          N3     113.157    1.50
-D65         C13         C12          N3     123.421    3.00
-D65         C11          N4         C12     103.688    1.50
-D65          F2         C13         C12     112.224    1.50
-D65          F2         C13         C14     106.664    1.50
-D65          F2         C13          F1     107.683    1.50
-D65         C12         C13         C14     110.747    2.16
-D65         C12         C13          F1     112.224    1.50
-D65         C14         C13          F1     106.664    1.50
-D65         C13         C14         H10     109.520    1.50
-D65         C13         C14         H11     109.520    1.50
-D65         C13         C14         H12     109.520    1.50
-D65         H10         C14         H11     109.399    1.50
-D65         H10         C14         H12     109.399    1.50
-D65         H11         C14         H12     109.399    1.50
+D65          F3          S1          C5      90.000    3.00
+D65          F3          S1          F4      90.000    3.00
+D65          F3          S1          F7      90.000    3.00
+D65          F3          S1          F5      90.000    3.00
+D65          F3          S1          F6     180.000    3.00
+D65          C5          S1          F4      90.000    3.00
+D65          C5          S1          F7      90.000    3.00
+D65          C5          S1          F5     180.000    3.00
+D65          C5          S1          F6      90.000    3.00
+D65          F4          S1          F7     180.000    3.00
+D65          F4          S1          F5      90.000    3.00
+D65          F4          S1          F6      90.000    3.00
+D65          F7          S1          F5      90.000    3.00
+D65          F7          S1          F6      90.000    3.00
+D65          F5          S1          F6      90.000    3.00
+D65          C6          C5          C4     121.153    1.50
+D65          C6          C5          S1     119.424    1.50
+D65          C4          C5          S1     119.424    1.50
+D65          C3          C4          C5     119.510    1.50
+D65          C3          C4          H1     120.041    1.50
+D65          C5          C4          H1     120.455    1.50
+D65          C2          C3          C4     120.476    1.50
+D65          C2          C3          H2     119.620    1.50
+D65          C4          C3          H2     119.903    1.50
+D65          C1          C6          C5     119.510    1.50
+D65          C1          C6          H3     120.041    1.50
+D65          C5          C6          H3     120.455    1.50
+D65          C2          C1          C6     120.476    1.50
+D65          C2          C1          H4     119.620    1.50
+D65          C6          C1          H4     119.903    1.50
+D65          N1          C2          C1     120.569    3.00
+D65          N1          C2          C3     120.569    3.00
+D65          C1          C2          C3     118.862    1.50
+D65          C7          N1          C2     126.486    3.00
+D65          C7          N1          H5     116.827    3.00
+D65          C2          N1          H5     116.687    3.00
+D65          C8          C7          N2     116.324    1.50
+D65          C8          C7          N1     123.172    3.00
+D65          N2          C7          N1     120.504    3.00
+D65          C9          C8          C7     120.508    1.50
+D65          C9          C8          H6     119.518    1.50
+D65          C7          C8          H6     119.974    1.50
+D65         C10          C9          N5     117.241    1.50
+D65         C10          C9          C8     120.610    1.50
+D65          N5          C9          C8     122.150    1.50
+D65          C9         C10          H7     109.544    1.50
+D65          C9         C10          H8     109.544    1.50
+D65          C9         C10          H9     109.544    1.50
+D65          H7         C10          H8     109.327    3.00
+D65          H7         C10          H9     109.327    3.00
+D65          H8         C10          H9     109.327    3.00
+D65         C11          N2          C7     122.794    1.50
+D65         C11          N2          N3     109.647    1.50
+D65          C7          N2          N3     127.559    2.57
+D65          N5         C11          N4     129.328    1.50
+D65          N5         C11          N2     121.783    1.50
+D65          N4         C11          N2     108.888    1.50
+D65          C9          N5         C11     116.442    1.50
+D65          N2          N3         C12     103.155    1.50
+D65          N4         C12         C13     124.068    3.00
+D65          N4         C12          N3     111.863    1.50
+D65         C13         C12          N3     124.068    3.00
+D65         C11          N4         C12     106.446    3.00
+D65          F2         C13         C12     110.375    1.50
+D65          F2         C13         C14     105.965    3.00
+D65          F2         C13          F1     107.369    1.50
+D65         C12         C13         C14     113.413    1.69
+D65         C12         C13          F1     110.375    1.50
+D65         C14         C13          F1     105.965    3.00
+D65         C13         C14         H10     109.543    1.50
+D65         C13         C14         H11     109.543    1.50
+D65         C13         C14         H12     109.543    1.50
+D65         H10         C14         H11     109.379    1.50
+D65         H10         C14         H12     109.379    1.50
+D65         H11         C14         H12     109.379    1.50
 loop_
 _chem_comp_tor.comp_id
 _chem_comp_tor.id
@@ -203,89 +246,98 @@ _chem_comp_tor.atom_id_4
 _chem_comp_tor.value_angle
 _chem_comp_tor.value_angle_esd
 _chem_comp_tor.period
-D65              const_20          C6          C1          C2          N1     180.000    10.0     2
-D65            sp2_sp2_21          C1          C2          N1          C7     180.000     5.0     2
-D65            sp2_sp2_17          C8          C7          N1          C2     180.000     5.0     2
-D65             sp2_sp2_3          N1          C7          C8          C9     180.000     5.0     2
-D65            sp2_sp2_15          N1          C7          N2         C11     180.000     5.0     2
-D65             sp2_sp2_6          C7          C8          C9         C10     180.000     5.0     2
+D65              const_32          C6          C1          C2          N1     180.000     0.0     2
+D65            sp2_sp2_53          C1          C2          N1          C7     180.000      20     2
+D65            sp2_sp2_49          C8          C7          N1          C2     180.000      20     2
+D65              const_13          N1          C7          C8          C9     180.000     0.0     2
+D65              const_45          N1          C7          N2         C11     180.000     0.0     2
+D65              const_16          C7          C8          C9         C10     180.000     0.0     2
 D65             sp2_sp3_1          N5          C9         C10          H7     150.000    10.0     6
-D65            sp2_sp2_10         C10          C9          N5         C11     180.000     5.0     2
-D65       const_sp2_sp2_1          N5         C11          N2          C7       0.000     5.0     2
-D65              const_31         C11          N2          N3         C12       0.000    10.0     2
-D65            sp2_sp2_12          N4         C11          N5          C9     180.000     5.0     2
-D65       const_sp2_sp2_6          N5         C11          N4         C12     180.000     5.0     2
-D65              const_10         C13         C12          N3          N2     180.000    10.0     2
-D65       const_sp2_sp2_8         C13         C12          N4         C11     180.000     5.0     2
-D65             sp2_sp3_8          N4         C12         C13          F2     -90.000    10.0     6
+D65              const_20         C10          C9          N5         C11     180.000     0.0     2
+D65       const_sp2_sp2_1          N5         C11          N2          C7       0.000     0.0     2
+D65              const_47         C11          N2          N3         C12       0.000     0.0     2
+D65              const_22          N4         C11          N5          C9     180.000     0.0     2
+D65       const_sp2_sp2_6          N5         C11          N4         C12     180.000     0.0     2
+D65              const_10         C13         C12          N3          N2     180.000     0.0     2
+D65       const_sp2_sp2_8         C13         C12          N4         C11     180.000     0.0     2
+D65             sp2_sp3_7          N4         C12         C13          F2     150.000    10.0     6
 D65             sp3_sp3_1          F2         C13         C14         H10     180.000    10.0     3
-D65              const_34          C3          C4          C5          S1     180.000    10.0     2
-D65              const_13          S1          C5          C6          C1     180.000    10.0     2
-D65              const_27          C2          C3          C4          C5       0.000    10.0     2
-D65              const_25          N1          C2          C3          C4     180.000    10.0     2
-D65              const_15          C2          C1          C6          C5       0.000    10.0     2
-loop_
-_chem_comp_chir.comp_id
-_chem_comp_chir.id
-_chem_comp_chir.atom_id_centre
-_chem_comp_chir.atom_id_1
-_chem_comp_chir.atom_id_2
-_chem_comp_chir.atom_id_3
-_chem_comp_chir.volume_sign
-D65    chir_1    C13    F2    F1    C12    both
+D65              const_58          C3          C4          C5          S1     180.000     0.0     2
+D65              const_25          S1          C5          C6          C1     180.000     0.0     2
+D65              const_39          C2          C3          C4          C5       0.000     0.0     2
+D65              const_37          N1          C2          C3          C4     180.000     0.0     2
+D65              const_27          C2          C1          C6          C5       0.000     0.0     2
 loop_
 _chem_comp_plane_atom.comp_id
 _chem_comp_plane_atom.plane_id
 _chem_comp_plane_atom.atom_id
 _chem_comp_plane_atom.dist_esd
-D65    plan-1         C10   0.020
-D65    plan-1         C11   0.020
-D65    plan-1         C12   0.020
-D65    plan-1         C13   0.020
-D65    plan-1          C7   0.020
-D65    plan-1          C8   0.020
-D65    plan-1          C9   0.020
-D65    plan-1          H6   0.020
+D65    plan-1          C1   0.020
+D65    plan-1          C2   0.020
+D65    plan-1          C3   0.020
+D65    plan-1          C4   0.020
+D65    plan-1          C5   0.020
+D65    plan-1          C6   0.020
+D65    plan-1          H1   0.020
+D65    plan-1          H2   0.020
+D65    plan-1          H3   0.020
+D65    plan-1          H4   0.020
 D65    plan-1          N1   0.020
-D65    plan-1          N2   0.020
-D65    plan-1          N3   0.020
-D65    plan-1          N4   0.020
-D65    plan-1          N5   0.020
-D65    plan-2          C1   0.020
-D65    plan-2          C2   0.020
-D65    plan-2          C3   0.020
-D65    plan-2          C4   0.020
-D65    plan-2          C5   0.020
-D65    plan-2          C6   0.020
-D65    plan-2          H1   0.020
-D65    plan-2          H2   0.020
-D65    plan-2          H3   0.020
-D65    plan-2          H4   0.020
+D65    plan-1          S1   0.020
+D65    plan-2         C10   0.020
+D65    plan-2         C11   0.020
+D65    plan-2          C7   0.020
+D65    plan-2          C8   0.020
+D65    plan-2          C9   0.020
+D65    plan-2          H6   0.020
 D65    plan-2          N1   0.020
-D65    plan-2          S1   0.020
-D65    plan-3          C2   0.020
+D65    plan-2          N2   0.020
+D65    plan-2          N3   0.020
+D65    plan-2          N4   0.020
+D65    plan-2          N5   0.020
+D65    plan-3         C11   0.020
+D65    plan-3         C12   0.020
+D65    plan-3         C13   0.020
 D65    plan-3          C7   0.020
-D65    plan-3          H5   0.020
-D65    plan-3          N1   0.020
+D65    plan-3          N2   0.020
+D65    plan-3          N3   0.020
+D65    plan-3          N4   0.020
+D65    plan-3          N5   0.020
+D65    plan-4          C2   0.020
+D65    plan-4          C7   0.020
+D65    plan-4          H5   0.020
+D65    plan-4          N1   0.020
+D65    plan-5          C7   0.020
+D65    plan-5          C8   0.020
+D65    plan-5          N1   0.020
+D65    plan-5          N2   0.020
+D65    plan-6          C7   0.020
+D65    plan-6          C8   0.020
+D65    plan-6          C9   0.020
+D65    plan-6          H6   0.020
+D65    plan-7         C10   0.020
+D65    plan-7          C8   0.020
+D65    plan-7          C9   0.020
+D65    plan-7          N5   0.020
 loop_
 _pdbx_chem_comp_descriptor.comp_id
 _pdbx_chem_comp_descriptor.type
 _pdbx_chem_comp_descriptor.program
 _pdbx_chem_comp_descriptor.program_version
 _pdbx_chem_comp_descriptor.descriptor
-D65           SMILES              ACDLabs 12.01                                                                 FS(F)(F)(F)(F)c1ccc(cc1)Nc2cc(nc3nc(nn23)C(F)(F)C)C
-D65            InChI                InChI  1.03 InChI=1S/C14H12F7N5S/c1-8-7-11(26-13(22-8)24-12(25-26)14(2,15)16)23-9-3-5-10(6-4-9)27(17,18,19,20)21/h3-7,23H,1-2H3
-D65         InChIKey                InChI  1.03                                                                                         OIZSVTOIBNSVOS-UHFFFAOYSA-N
-D65 SMILES_CANONICAL               CACTVS 3.385                                                               Cc1cc(Nc2ccc(cc2)[S](F)(F)(F)(F)F)n3nc(nc3n1)C(C)(F)F
-D65           SMILES               CACTVS 3.385                                                               Cc1cc(Nc2ccc(cc2)[S](F)(F)(F)(F)F)n3nc(nc3n1)C(C)(F)F
-D65 SMILES_CANONICAL "OpenEye OEToolkits" 1.7.6                                                               Cc1cc(n2c(n1)nc(n2)C(C)(F)F)Nc3ccc(cc3)S(F)(F)(F)(F)F
-D65           SMILES "OpenEye OEToolkits" 1.7.6                                                               Cc1cc(n2c(n1)nc(n2)C(C)(F)F)Nc3ccc(cc3)S(F)(F)(F)(F)F
+D65  SMILES            ACDLabs               12.01  "FS(F)(F)(F)(F)c1ccc(cc1)Nc2cc(nc3nc(nn23)C(F)(F)C)C"
+D65  InChI             InChI                 1.03   "InChI=1S/C14H12F7N5S/c1-8-7-11(26-13(22-8)24-12(25-26)14(2,15)16)23-9-3-5-10(6-4-9)27(17,18,19,20)21/h3-7,23H,1-2H3"
+D65  InChIKey          InChI                 1.03   OIZSVTOIBNSVOS-UHFFFAOYSA-N
+D65  SMILES_CANONICAL  CACTVS                3.385  "Cc1cc(Nc2ccc(cc2)[S](F)(F)(F)(F)F)n3nc(nc3n1)C(C)(F)F"
+D65  SMILES            CACTVS                3.385  "Cc1cc(Nc2ccc(cc2)[S](F)(F)(F)(F)F)n3nc(nc3n1)C(C)(F)F"
+D65  SMILES_CANONICAL  "OpenEye OEToolkits"  1.7.6  "Cc1cc(n2c(n1)nc(n2)C(C)(F)F)Nc3ccc(cc3)S(F)(F)(F)(F)F"
+D65  SMILES            "OpenEye OEToolkits"  1.7.6  "Cc1cc(n2c(n1)nc(n2)C(C)(F)F)Nc3ccc(cc3)S(F)(F)(F)(F)F"
 loop_
 _pdbx_chem_comp_description_generator.comp_id
 _pdbx_chem_comp_description_generator.program_name
 _pdbx_chem_comp_description_generator.program_version
 _pdbx_chem_comp_description_generator.descriptor
-D65 acedrg               243         "dictionary generator"                  
-D65 acedrg_database      11          "data source"                           
-D65 rdkit                2017.03.2   "Chemoinformatics tool"
-D65 refmac5              5.8.0238    "optimization tool"                     
+D65 acedrg               272         "dictionary generator"                  
+D65 acedrg_database      12          "data source"                           
+D65 rdkit                2019.09.1   "Chemoinformatics tool"
+D65 refmac5              5.8.0405    "optimization tool"                     

--- a/p/PO2.cif
+++ b/p/PO2.cif
@@ -21,9 +21,9 @@ _chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-PO2     P       P       P1      0       23.394      19.765      22.198      
-PO2     O1      O       OP      -1      22.653      19.961      23.458      
-PO2     O2      O       O       0       23.998      18.454      21.893      
+PO2     P       P       P1      0       23.392      19.781      22.187      
+PO2     O1      O       OP      -1      22.654      19.857      23.462      
+PO2     O2      O       O       0       23.999      18.444      22.049      
 loop_
 _chem_comp_acedrg.comp_id
 _chem_comp_acedrg.atom_id
@@ -50,7 +50,7 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-PO2          O1           P          O2     120.000    3.00
+PO2          O1           P          O2     109.471    3.00
 loop_
 _pdbx_chem_comp_descriptor.comp_id
 _pdbx_chem_comp_descriptor.type

--- a/p/PO2.cif
+++ b/p/PO2.cif
@@ -21,9 +21,16 @@ _chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-PO2     P       P       P1      0       23.213      19.919      22.063      
-PO2     O1      O       OP      -1      22.670      18.751      23.164      
-PO2     O2      O       O       0       22.670      18.748      23.160      
+PO2     P       P       P1      0       23.394      19.765      22.198      
+PO2     O1      O       OP      -1      22.653      19.961      23.458      
+PO2     O2      O       O       0       23.998      18.454      21.893      
+loop_
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+PO2     P    P(O)2
+PO2    O1    O(PO)
+PO2    O2    O(PO)
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
@@ -34,8 +41,8 @@ _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-PO2           P          O1      SINGLE       n     1.694  0.0200     1.694  0.0200
-PO2           P          O2      DOUBLE       n     1.694  0.0200     1.694  0.0200
+PO2           P          O1      SINGLE       n     1.475  0.0100     1.475  0.0100
+PO2           P          O2      DOUBLE       n     1.475  0.0100     1.475  0.0100
 loop_
 _chem_comp_angle.comp_id
 _chem_comp_angle.atom_id_1
@@ -43,25 +50,25 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-PO2          O1           P          O2       0.000    3.00
+PO2          O1           P          O2     120.000    3.00
 loop_
 _pdbx_chem_comp_descriptor.comp_id
 _pdbx_chem_comp_descriptor.type
 _pdbx_chem_comp_descriptor.program
 _pdbx_chem_comp_descriptor.program_version
 _pdbx_chem_comp_descriptor.descriptor
-PO2 SMILES_CANONICAL               CACTVS 3.341                         "[O-]P=O"
-PO2           SMILES               CACTVS 3.341                         "[O-]P=O"
-PO2 SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0                         "[O-]P=O"
-PO2           SMILES "OpenEye OEToolkits" 1.5.0                         "[O-]P=O"
-PO2            InChI                InChI  1.03 InChI=1S/HO2P/c1-3-2/h(H,1,2)/p-1
-PO2         InChIKey                InChI  1.03       GQZXNSPRSGFJLY-UHFFFAOYSA-M
+PO2 SMILES_CANONICAL CACTVS               3.341 "[O-]P=O"
+PO2 SMILES           CACTVS               3.341 "[O-]P=O"
+PO2 SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0 "[O-]P=O"
+PO2 SMILES           "OpenEye OEToolkits" 1.5.0 "[O-]P=O"
+PO2 InChI            InChI                1.03  "InChI=1S/HO2P/c1-3-2/h(H,1,2)/p-1"
+PO2 InChIKey         InChI                1.03  GQZXNSPRSGFJLY-UHFFFAOYSA-M
 loop_
 _pdbx_chem_comp_description_generator.comp_id
 _pdbx_chem_comp_description_generator.program_name
 _pdbx_chem_comp_description_generator.program_version
 _pdbx_chem_comp_description_generator.descriptor
-PO2 acedrg               243         "dictionary generator"                  
-PO2 acedrg_database      11          "data source"                           
-PO2 rdkit                2017.03.2   "Chemoinformatics tool"
-PO2 refmac5              5.8.0238    "optimization tool"                     
+PO2 acedrg               272         "dictionary generator"                  
+PO2 acedrg_database      12          "data source"                           
+PO2 rdkit                2019.09.1   "Chemoinformatics tool"
+PO2 refmac5              5.8.0405    "optimization tool"                     

--- a/q/Q0S.cif
+++ b/q/Q0S.cif
@@ -8,7 +8,7 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-Q0S     Q0S      5-bromo-2-hydroxy-N-[3-(methylsulfonyl)-5-(pentafluoro-lambda~6~-sulfanyl)phenyl]benzene-1-sulfonamide     NON-POLYMER     39     28     .     
+Q0S     Q0S      "5-bromo-2-hydroxy-N-[3-(methylsulfonyl)-5-(pentafluoro-lambda~6~-sulfanyl)phenyl]benzene-1-sulfonamide"     NON-POLYMER     39     28     .     
 #
 data_comp_Q0S
 #
@@ -21,45 +21,88 @@ _chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-Q0S     C10     C       CR6     0       137.446     5.944       18.829      
-Q0S     C13     C       CH3     0       140.986     2.249       12.458      
-Q0S     C01     C       CR16    0       140.044     4.499       17.181      
-Q0S     C02     C       CR6     0       141.201     4.623       16.295      
-Q0S     C03     C       CR16    0       140.915     4.374       14.861      
-Q0S     C04     C       CR6     0       139.761     3.697       14.492      
-Q0S     C05     C       CR16    0       138.757     3.436       15.412      
-Q0S     C06     C       CR6     0       138.902     3.822       16.746      
-Q0S     C07     C       CR16    0       137.449     8.712       18.486      
-Q0S     C08     C       CR6     0       138.291     8.127       19.414      
-Q0S     C09     C       CR16    0       138.299     6.758       19.597      
-Q0S     C11     C       CR6     0       136.584     6.544       17.886      
-Q0S     C12     C       CR16    0       136.602     7.926       17.727      
-Q0S     F01     F       F       0       142.077     4.189       16.642      
-Q0S     F02     F       F       0       142.077     4.189       16.642      
-Q0S     F03     F       F       0       142.077     4.189       16.642      
-Q0S     F04     F       F       0       142.077     4.189       16.642      
-Q0S     F05     F       F       0       142.077     4.189       16.642      
-Q0S     N01     N       NH1     0       137.832     3.508       17.636      
-Q0S     O01     O       O       0       136.103     3.796       19.345      
-Q0S     O02     O       O       0       138.484     3.849       19.984      
-Q0S     O03     O       OH1     0       135.730     5.789       17.116      
-Q0S     O04     O       O       0       138.410     2.350       12.701      
-Q0S     O05     O       O       0       139.597     4.385       11.989      
-Q0S     S01     S       S3      0       137.446     4.195       19.062      
-Q0S     S02     S       S3      0       139.558     3.206       12.805      
-Q0S     S03     S       S       0       142.660     5.653       16.797      
-Q0S     BR1     BR      BR      0       139.450     9.217       20.450      
-Q0S     H1      H       H       0       141.413     1.998       13.286      
-Q0S     H2      H       H       0       141.598     2.769       11.923      
-Q0S     H3      H       H       0       140.729     1.454       11.974      
-Q0S     H4      H       H       0       140.124     4.725       18.115      
-Q0S     H5      H       H       0       141.589     4.509       14.202      
-Q0S     H6      H       H       0       137.964     2.996       15.140      
-Q0S     H7      H       H       0       137.451     9.642       18.369      
-Q0S     H8      H       H       0       138.874     6.376       20.228      
-Q0S     H9      H       H       0       136.031     8.331       17.096      
-Q0S     H10     H       H       0       137.314     2.860       17.395      
-Q0S     H11     H       H       0       135.387     5.067       17.434      
+Q0S     C10     C       CR6     0       137.263     6.167       18.467      
+Q0S     C13     C       CH3     0       140.267     3.183       12.159      
+Q0S     C01     C       CR16    0       140.612     3.722       17.392      
+Q0S     C02     C       CR6     0       141.646     3.864       16.471      
+Q0S     C03     C       CR16    0       141.355     4.130       15.133      
+Q0S     C04     C       CR6     0       140.026     4.255       14.717      
+Q0S     C05     C       CR16    0       138.993     4.114       15.630      
+Q0S     C06     C       CR6     0       139.289     3.857       16.969      
+Q0S     C07     C       CR16    0       136.312     8.544       17.368      
+Q0S     C08     C       CR6     0       137.418     8.546       18.196      
+Q0S     C09     C       CR16    0       137.899     7.372       18.748      
+Q0S     C11     C       CR6     0       136.139     6.153       17.628      
+Q0S     C12     C       CR16    0       135.674     7.350       17.084      
+Q0S     F01     F       F       0       143.787     4.996       16.188      
+Q0S     F02     F       F       0       143.110     4.621       18.264      
+Q0S     F03     F       F       0       143.034     2.402       17.838      
+Q0S     F04     F       F       0       144.879     3.561       17.466      
+Q0S     F05     F       F       0       143.710     2.776       15.762      
+Q0S     N01     N       NH1     0       138.215     3.708       17.894      
+Q0S     O01     O       O       0       136.786     4.032       19.853      
+Q0S     O02     O       O       0       139.088     4.916       19.871      
+Q0S     O03     O       OH1     0       135.488     4.999       17.327      
+Q0S     O04     O       O       0       138.250     4.662       12.838      
+Q0S     O05     O       O       0       140.458     5.727       12.616      
+Q0S     S01     S       S3      0       137.869     4.665       19.166      
+Q0S     S02     S       S3      0       139.672     4.594       13.016      
+Q0S     S03     S       S       0       143.373     3.702       17.001      
+Q0S     BR1     BR      BR      0       138.292     10.186      18.585      
+Q0S     H1      H       H       0       140.641     2.557       12.795      
+Q0S     H2      H       H       0       140.949     3.455       11.529      
+Q0S     H3      H       H       0       139.534     2.765       11.684      
+Q0S     H4      H       H       0       140.799     3.543       18.298      
+Q0S     H5      H       H       0       142.041     4.227       14.499      
+Q0S     H6      H       H       0       138.098     4.199       15.359      
+Q0S     H7      H       H       0       135.993     9.349       16.998      
+Q0S     H8      H       H       0       138.655     7.392       19.311      
+Q0S     H9      H       H       0       134.919     7.343       16.520      
+Q0S     H10     H       H       0       137.686     3.045       17.778      
+Q0S     H11     H       H       0       135.835     4.333       17.796      
+loop_
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+Q0S   C10    C[6a](C[6a]C[6a]H)(C[6a]C[6a]O)(SNOO){1|Br<1>,1|C<3>,1|H<1>}
+Q0S   C13    C(SC[6a]OO)(H)3
+Q0S   C01    C[6a](C[6a]C[6a]N)(C[6a]C[6a]S)(H){1|C<3>,2|H<1>}
+Q0S   C02    C[6a](C[6a]C[6a]H)2(SF5){1|C<3>,1|N<3>,1|S<4>}
+Q0S   C03    C[6a](C[6a]C[6a]S)2(H){1|C<3>,2|H<1>}
+Q0S   C04    C[6a](C[6a]C[6a]H)2(SCOO){1|C<3>,1|N<3>,1|S<6>}
+Q0S   C05    C[6a](C[6a]C[6a]N)(C[6a]C[6a]S)(H){1|C<3>,2|H<1>}
+Q0S   C06    C[6a](C[6a]C[6a]H)2(NHS){1|C<3>,1|S<4>,1|S<6>}
+Q0S   C07    C[6a](C[6a]C[6a]Br)(C[6a]C[6a]H)(H){1|C<3>,1|H<1>,1|O<2>}
+Q0S   C08    C[6a](C[6a]C[6a]H)2(Br){1|C<3>,1|H<1>,1|S<4>}
+Q0S   C09    C[6a](C[6a]C[6a]Br)(C[6a]C[6a]S)(H){1|C<3>,1|H<1>,1|O<2>}
+Q0S   C11    C[6a](C[6a]C[6a]H)(C[6a]C[6a]S)(OH){1|C<3>,2|H<1>}
+Q0S   C12    C[6a](C[6a]C[6a]H)(C[6a]C[6a]O)(H){1|Br<1>,1|C<3>,1|S<4>}
+Q0S   F01    F(SC[6a]F4)
+Q0S   F02    F(SC[6a]F4)
+Q0S   F03    F(SC[6a]F4)
+Q0S   F04    F(SC[6a]F4)
+Q0S   F05    F(SC[6a]F4)
+Q0S   N01    N(C[6a]C[6a]2)(SC[6a]OO)(H)
+Q0S   O01    O(SC[6a]NO)
+Q0S   O02    O(SC[6a]NO)
+Q0S   O03    O(C[6a]C[6a]2)(H)
+Q0S   O04    O(SC[6a]CO)
+Q0S   O05    O(SC[6a]CO)
+Q0S   S01    S(C[6a]C[6a]2)(NC[6a]H)(O)2
+Q0S   S02    S(C[6a]C[6a]2)(CH3)(O)2
+Q0S   S03    S(C[6a]C[6a]2)(F)5
+Q0S   BR1    Br(C[6a]C[6a]2)
+Q0S    H1    H(CHHS)
+Q0S    H2    H(CHHS)
+Q0S    H3    H(CHHS)
+Q0S    H4    H(C[6a]C[6a]2)
+Q0S    H5    H(C[6a]C[6a]2)
+Q0S    H6    H(C[6a]C[6a]2)
+Q0S    H7    H(C[6a]C[6a]2)
+Q0S    H8    H(C[6a]C[6a]2)
+Q0S    H9    H(C[6a]C[6a]2)
+Q0S   H10    H(NC[6a]S)
+Q0S   H11    H(OC[6a])
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
@@ -70,46 +113,46 @@ _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-Q0S         C13         S02      SINGLE       n     1.753  0.0100     1.753  0.0100
+Q0S         C13         S02      SINGLE       n     1.754  0.0100     1.754  0.0100
 Q0S         O05         S02      DOUBLE       n     1.435  0.0100     1.435  0.0100
 Q0S         O04         S02      DOUBLE       n     1.435  0.0100     1.435  0.0100
-Q0S         C04         S02      SINGLE       n     1.767  0.0100     1.767  0.0100
-Q0S         C03         C04      DOUBLE       y     1.385  0.0100     1.385  0.0100
-Q0S         C04         C05      SINGLE       y     1.381  0.0107     1.381  0.0107
-Q0S         C02         C03      SINGLE       y     1.383  0.0155     1.383  0.0155
-Q0S         C05         C06      DOUBLE       y     1.391  0.0100     1.391  0.0100
-Q0S         F01         S03      SINGLE       n     1.587  0.0100     1.587  0.0100
-Q0S         F05         S03      SINGLE       n     1.587  0.0100     1.587  0.0100
-Q0S         C02         S03      SINGLE       n     1.805  0.0100     1.805  0.0100
-Q0S         C01         C02      DOUBLE       y     1.383  0.0137     1.383  0.0137
-Q0S         C01         C06      SINGLE       y     1.391  0.0100     1.391  0.0100
-Q0S         C06         N01      SINGLE       n     1.420  0.0112     1.420  0.0112
-Q0S         F04         S03      SINGLE       n     1.587  0.0100     1.587  0.0100
-Q0S         F02         S03      SINGLE       n     1.587  0.0100     1.587  0.0100
-Q0S         F03         S03      SINGLE       n     1.587  0.0100     1.587  0.0100
-Q0S         C07         C12      DOUBLE       y     1.375  0.0117     1.375  0.0117
-Q0S         C11         C12      SINGLE       y     1.387  0.0100     1.387  0.0100
-Q0S         C07         C08      SINGLE       y     1.377  0.0121     1.377  0.0121
-Q0S         C11         O03      SINGLE       n     1.374  0.0155     1.374  0.0155
-Q0S         C10         C11      DOUBLE       y     1.407  0.0102     1.407  0.0102
-Q0S         N01         S01      SINGLE       n     1.627  0.0106     1.627  0.0106
+Q0S         C04         S02      SINGLE       n     1.769  0.0100     1.769  0.0100
+Q0S         C03         C04      DOUBLE       y     1.394  0.0106     1.394  0.0106
+Q0S         C04         C05      SINGLE       y     1.381  0.0100     1.381  0.0100
+Q0S         C02         C03      SINGLE       y     1.387  0.0119     1.387  0.0119
+Q0S         C05         C06      DOUBLE       y     1.392  0.0100     1.392  0.0100
+Q0S         F01         S03      SINGLE       n     1.583  0.0100     1.583  0.0100
+Q0S         F05         S03      SINGLE       n     1.583  0.0100     1.583  0.0100
+Q0S         C02         S03      SINGLE       n     1.807  0.0100     1.807  0.0100
+Q0S         C01         C02      DOUBLE       y     1.386  0.0100     1.386  0.0100
+Q0S         C01         C06      SINGLE       y     1.391  0.0103     1.391  0.0103
+Q0S         C06         N01      SINGLE       n     1.424  0.0133     1.424  0.0133
+Q0S         F04         S03      SINGLE       n     1.583  0.0100     1.583  0.0100
+Q0S         F02         S03      SINGLE       n     1.583  0.0100     1.583  0.0100
+Q0S         F03         S03      SINGLE       n     1.583  0.0100     1.583  0.0100
+Q0S         C07         C12      DOUBLE       y     1.377  0.0124     1.377  0.0124
+Q0S         C11         C12      SINGLE       y     1.389  0.0100     1.389  0.0100
+Q0S         C07         C08      SINGLE       y     1.377  0.0130     1.377  0.0130
+Q0S         C11         O03      SINGLE       n     1.358  0.0100     1.358  0.0100
+Q0S         C10         C11      DOUBLE       y     1.397  0.0100     1.397  0.0100
+Q0S         N01         S01      SINGLE       n     1.628  0.0112     1.628  0.0112
 Q0S         C08         BR1      SINGLE       n     1.899  0.0100     1.899  0.0100
-Q0S         C08         C09      DOUBLE       y     1.379  0.0100     1.379  0.0100
-Q0S         C10         C09      SINGLE       y     1.398  0.0166     1.398  0.0166
-Q0S         C10         S01      SINGLE       n     1.761  0.0110     1.761  0.0110
+Q0S         C08         C09      DOUBLE       y     1.382  0.0100     1.382  0.0100
+Q0S         C10         C09      SINGLE       y     1.387  0.0100     1.387  0.0100
+Q0S         C10         S01      SINGLE       n     1.762  0.0100     1.762  0.0100
 Q0S         O02         S01      DOUBLE       n     1.430  0.0100     1.430  0.0100
 Q0S         O01         S01      DOUBLE       n     1.430  0.0100     1.430  0.0100
-Q0S         C13          H1      SINGLE       n     1.089  0.0100     0.965  0.0106
-Q0S         C13          H2      SINGLE       n     1.089  0.0100     0.965  0.0106
-Q0S         C13          H3      SINGLE       n     1.089  0.0100     0.965  0.0106
-Q0S         C01          H4      SINGLE       n     1.082  0.0130     0.949  0.0200
-Q0S         C03          H5      SINGLE       n     1.082  0.0130     0.947  0.0100
-Q0S         C05          H6      SINGLE       n     1.082  0.0130     0.949  0.0200
-Q0S         C07          H7      SINGLE       n     1.082  0.0130     0.937  0.0101
-Q0S         C09          H8      SINGLE       n     1.082  0.0130     0.937  0.0200
-Q0S         C12          H9      SINGLE       n     1.082  0.0130     0.942  0.0170
-Q0S         N01         H10      SINGLE       n     1.016  0.0100     0.863  0.0160
-Q0S         O03         H11      SINGLE       n     0.966  0.0059     0.861  0.0200
+Q0S         C13          H1      SINGLE       n     1.089  0.0100     0.968  0.0130
+Q0S         C13          H2      SINGLE       n     1.089  0.0100     0.968  0.0130
+Q0S         C13          H3      SINGLE       n     1.089  0.0100     0.968  0.0130
+Q0S         C01          H4      SINGLE       n     1.082  0.0130     0.942  0.0100
+Q0S         C03          H5      SINGLE       n     1.082  0.0130     0.939  0.0154
+Q0S         C05          H6      SINGLE       n     1.082  0.0130     0.939  0.0108
+Q0S         C07          H7      SINGLE       n     1.082  0.0130     0.941  0.0133
+Q0S         C09          H8      SINGLE       n     1.082  0.0130     0.943  0.0117
+Q0S         C12          H9      SINGLE       n     1.082  0.0130     0.942  0.0182
+Q0S         N01         H10      SINGLE       n     1.016  0.0100     0.856  0.0200
+Q0S         O03         H11      SINGLE       n     0.966  0.0059     0.858  0.0200
 loop_
 _chem_comp_angle.comp_id
 _chem_comp_angle.atom_id_1
@@ -117,79 +160,79 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-Q0S         C11         C10         C09     120.148    1.50
-Q0S         C11         C10         S01     120.480    1.50
-Q0S         C09         C10         S01     119.371    1.50
-Q0S         S02         C13          H1     109.379    1.50
-Q0S         S02         C13          H2     109.379    1.50
-Q0S         S02         C13          H3     109.379    1.50
-Q0S          H1         C13          H2     109.535    1.86
-Q0S          H1         C13          H3     109.535    1.86
-Q0S          H2         C13          H3     109.535    1.86
-Q0S         C02         C01         C06     120.055    1.50
-Q0S         C02         C01          H4     119.936    1.50
-Q0S         C06         C01          H4     120.010    1.50
-Q0S         C03         C02         S03     119.973    1.50
-Q0S         C03         C02         C01     120.055    1.50
-Q0S         S03         C02         C01     119.973    1.50
-Q0S         C04         C03         C02     120.055    1.50
-Q0S         C04         C03          H5     119.874    1.50
-Q0S         C02         C03          H5     120.071    1.50
-Q0S         S02         C04         C03     120.029    1.50
-Q0S         S02         C04         C05     119.563    1.50
-Q0S         C03         C04         C05     120.408    1.50
-Q0S         C04         C05         C06     119.181    1.50
-Q0S         C04         C05          H6     120.688    1.50
-Q0S         C06         C05          H6     120.131    1.50
-Q0S         C05         C06         C01     120.247    2.01
-Q0S         C05         C06         N01     119.877    2.34
-Q0S         C01         C06         N01     119.877    2.34
-Q0S         C12         C07         C08     119.538    1.50
-Q0S         C12         C07          H7     120.096    1.50
-Q0S         C08         C07          H7     120.366    1.50
-Q0S         C07         C08         BR1     119.620    1.50
-Q0S         C07         C08         C09     120.919    1.50
-Q0S         BR1         C08         C09     119.461    1.50
-Q0S         C08         C09         C10     120.372    1.50
-Q0S         C08         C09          H8     119.870    1.50
-Q0S         C10         C09          H8     119.758    1.50
-Q0S         C12         C11         O03     120.398    3.00
-Q0S         C12         C11         C10     119.204    1.50
-Q0S         O03         C11         C10     120.398    3.00
-Q0S         C07         C12         C11     119.818    1.50
-Q0S         C07         C12          H9     120.069    1.50
-Q0S         C11         C12          H9     120.113    1.50
-Q0S         C06         N01         S01     124.789    3.00
-Q0S         C06         N01         H10     117.772    1.74
-Q0S         S01         N01         H10     117.438    1.95
-Q0S         C11         O03         H11     120.000    3.00
-Q0S         N01         S01         C10     106.766    1.50
-Q0S         N01         S01         O02     106.760    2.22
-Q0S         N01         S01         O01     106.760    2.22
-Q0S         C10         S01         O02     108.022    1.50
-Q0S         C10         S01         O01     108.022    1.50
-Q0S         O02         S01         O01     119.445    1.50
-Q0S         C13         S02         O05     108.393    1.50
-Q0S         C13         S02         O04     108.393    1.50
-Q0S         C13         S02         C04     104.460    1.50
-Q0S         O05         S02         O04     118.198    1.50
-Q0S         O05         S02         C04     108.209    1.50
-Q0S         O04         S02         C04     108.209    1.50
-Q0S         F01         S03         F05       0.000    3.00
-Q0S         F01         S03         C02       0.000    3.00
-Q0S         F01         S03         F04       0.000    3.00
-Q0S         F01         S03         F02       0.000    3.00
-Q0S         F01         S03         F03       0.000    3.00
-Q0S         F05         S03         C02       0.000    3.00
-Q0S         F05         S03         F04       0.000    3.00
-Q0S         F05         S03         F02       0.000    3.00
-Q0S         F05         S03         F03       0.000    3.00
-Q0S         C02         S03         F04       0.000    3.00
-Q0S         C02         S03         F02       0.000    3.00
-Q0S         C02         S03         F03       0.000    3.00
-Q0S         F04         S03         F02       0.000    3.00
-Q0S         F04         S03         F03       0.000    3.00
-Q0S         F02         S03         F03       0.000    3.00
+Q0S         C11         C10         C09     120.200    1.50
+Q0S         C11         C10         S01     120.290    1.87
+Q0S         C09         C10         S01     119.510    1.50
+Q0S         S02         C13          H1     109.290    1.50
+Q0S         S02         C13          H2     109.290    1.50
+Q0S         S02         C13          H3     109.290    1.50
+Q0S          H1         C13          H2     109.616    2.70
+Q0S          H1         C13          H3     109.616    2.70
+Q0S          H2         C13          H3     109.616    2.70
+Q0S         C02         C01         C06     119.501    1.50
+Q0S         C02         C01          H4     120.162    1.50
+Q0S         C06         C01          H4     120.337    1.50
+Q0S         C03         C02         S03     119.106    1.50
+Q0S         C03         C02         C01     121.070    1.50
+Q0S         S03         C02         C01     119.824    1.50
+Q0S         C04         C03         C02     119.944    2.35
+Q0S         C04         C03          H5     119.452    1.50
+Q0S         C02         C03          H5     120.604    1.50
+Q0S         S02         C04         C03     120.099    1.50
+Q0S         S02         C04         C05     119.557    1.50
+Q0S         C03         C04         C05     120.344    1.50
+Q0S         C04         C05         C06     119.182    2.14
+Q0S         C04         C05          H6     120.608    1.57
+Q0S         C06         C05          H6     120.210    1.50
+Q0S         C05         C06         C01     119.958    3.00
+Q0S         C05         C06         N01     120.021    3.00
+Q0S         C01         C06         N01     120.021    3.00
+Q0S         C12         C07         C08     119.382    1.50
+Q0S         C12         C07          H7     120.171    1.50
+Q0S         C08         C07          H7     120.447    1.50
+Q0S         C07         C08         BR1     119.261    1.50
+Q0S         C07         C08         C09     121.557    1.50
+Q0S         BR1         C08         C09     119.182    1.50
+Q0S         C08         C09         C10     120.235    1.50
+Q0S         C08         C09          H8     119.931    1.50
+Q0S         C10         C09          H8     119.834    1.50
+Q0S         C12         C11         O03     120.325    3.00
+Q0S         C12         C11         C10     118.944    1.50
+Q0S         O03         C11         C10     120.730    3.00
+Q0S         C07         C12         C11     119.682    1.50
+Q0S         C07         C12          H9     120.272    1.50
+Q0S         C11         C12          H9     120.046    1.50
+Q0S         C06         N01         S01     125.772    3.00
+Q0S         C06         N01         H10     118.084    3.00
+Q0S         S01         N01         H10     116.144    3.00
+Q0S         C11         O03         H11     109.978    3.00
+Q0S         N01         S01         C10     106.063    2.85
+Q0S         N01         S01         O02     106.816    3.00
+Q0S         N01         S01         O01     106.816    3.00
+Q0S         C10         S01         O02     108.321    2.12
+Q0S         C10         S01         O01     108.321    2.12
+Q0S         O02         S01         O01     119.362    1.50
+Q0S         C13         S02         O05     108.430    1.50
+Q0S         C13         S02         O04     108.430    1.50
+Q0S         C13         S02         C04     104.471    1.50
+Q0S         O05         S02         O04     118.213    1.50
+Q0S         O05         S02         C04     108.143    1.50
+Q0S         O04         S02         C04     108.143    1.50
+Q0S         F01         S03         F05      90.000    3.00
+Q0S         F01         S03         C02      90.000    3.00
+Q0S         F01         S03         F04      90.000    3.00
+Q0S         F01         S03         F02      90.000    3.00
+Q0S         F01         S03         F03     180.000    3.00
+Q0S         F05         S03         C02      90.000    3.00
+Q0S         F05         S03         F04      90.000    3.00
+Q0S         F05         S03         F02     180.000    3.00
+Q0S         F05         S03         F03      90.000    3.00
+Q0S         C02         S03         F04     180.000    3.00
+Q0S         C02         S03         F02      90.000    3.00
+Q0S         C02         S03         F03      90.000    3.00
+Q0S         F04         S03         F02      90.000    3.00
+Q0S         F04         S03         F03      90.000    3.00
+Q0S         F02         S03         F03      90.000    3.00
 loop_
 _chem_comp_tor.comp_id
 _chem_comp_tor.id
@@ -200,34 +243,24 @@ _chem_comp_tor.atom_id_4
 _chem_comp_tor.value_angle
 _chem_comp_tor.value_angle_esd
 _chem_comp_tor.period
-Q0S              const_46         C08         C09         C10         S01     180.000    10.0     2
-Q0S              const_24         S01         C10         C11         O03       0.000    10.0     2
-Q0S            sp2_sp3_15         C11         C10         S01         N01      30.000    10.0     6
-Q0S              const_27         O03         C11         C12         C07     180.000    10.0     2
-Q0S             sp2_sp2_5         C12         C11         O03         H11     180.000     5.0     2
+Q0S              const_52         C08         C09         C10         S01     180.000     0.0     2
+Q0S              const_24         S01         C10         C11         O03       0.000     0.0     2
+Q0S            sp2_sp3_13         C11         C10         S01         N01     150.000    10.0     6
+Q0S              const_27         O03         C11         C12         C07     180.000     0.0     2
+Q0S            sp2_sp2_49         C12         C11         O03         H11     180.000      20     2
 Q0S             sp2_sp3_8         C06         N01         S01         O02     120.000    10.0     6
 Q0S             sp3_sp3_1          H1         C13         S02         O05     180.000    10.0     3
-Q0S       const_sp2_sp2_2         C06         C01         C02         S03     180.000     5.0     2
-Q0S              const_42         C02         C01         C06         N01     180.000    10.0     2
-Q0S       const_sp2_sp2_7         S03         C02         C03         C04     180.000     5.0     2
-Q0S              const_10         C02         C03         C04         S02     180.000    10.0     2
-Q0S             sp2_sp3_3         C03         C04         S02         C13      30.000    10.0     6
-Q0S              const_15         S02         C04         C05         C06     180.000    10.0     2
-Q0S              const_18         C04         C05         C06         N01     180.000    10.0     2
-Q0S             sp2_sp2_1         C05         C06         N01         S01     180.000     5.0     2
-Q0S              const_29         C08         C07         C12         C11       0.000    10.0     2
-Q0S              const_34         C12         C07         C08         BR1     180.000    10.0     2
-Q0S              const_39         BR1         C08         C09         C10     180.000    10.0     2
-loop_
-_chem_comp_chir.comp_id
-_chem_comp_chir.id
-_chem_comp_chir.atom_id_centre
-_chem_comp_chir.atom_id_1
-_chem_comp_chir.atom_id_2
-_chem_comp_chir.atom_id_3
-_chem_comp_chir.volume_sign
-Q0S    chir_1    S01    O02    O01    N01    both
-Q0S    chir_2    S02    O05    O04    C04    both
+Q0S       const_sp2_sp2_2         C06         C01         C02         S03     180.000     0.0     2
+Q0S              const_42         C02         C01         C06         N01     180.000     0.0     2
+Q0S       const_sp2_sp2_7         S03         C02         C03         C04     180.000     0.0     2
+Q0S              const_10         C02         C03         C04         S02     180.000     0.0     2
+Q0S             sp2_sp3_1         C03         C04         S02         C13     150.000    10.0     6
+Q0S              const_15         S02         C04         C05         C06     180.000     0.0     2
+Q0S              const_18         C04         C05         C06         N01     180.000     0.0     2
+Q0S            sp2_sp2_45         C05         C06         N01         S01     180.000      20     2
+Q0S              const_29         C08         C07         C12         C11       0.000     0.0     2
+Q0S              const_34         C12         C07         C08         BR1     180.000     0.0     2
+Q0S              const_39         BR1         C08         C09         C10     180.000     0.0     2
 loop_
 _chem_comp_plane_atom.comp_id
 _chem_comp_plane_atom.plane_id
@@ -267,19 +300,19 @@ _pdbx_chem_comp_descriptor.type
 _pdbx_chem_comp_descriptor.program
 _pdbx_chem_comp_descriptor.program_version
 _pdbx_chem_comp_descriptor.descriptor
-Q0S           SMILES              ACDLabs 12.01                                                              c1(cc(ccc1O)Br)S(Nc2cc(S(F)(F)(F)(F)F)cc(c2)S(C)(=O)=O)(=O)=O
-Q0S            InChI                InChI  1.03 InChI=1S/C13H11BrF5NO5S3/c1-26(22,23)10-5-9(6-11(7-10)28(15,16,17,18)19)20-27(24,25)13-4-8(14)2-3-12(13)21/h2-7,20-21H,1H3
-Q0S         InChIKey                InChI  1.03                                                                                                GXKWWSXTDOWSFB-UHFFFAOYSA-N
-Q0S SMILES_CANONICAL               CACTVS 3.385                                                          C[S](=O)(=O)c1cc(N[S](=O)(=O)c2cc(Br)ccc2O)cc(c1)[S](F)(F)(F)(F)F
-Q0S           SMILES               CACTVS 3.385                                                          C[S](=O)(=O)c1cc(N[S](=O)(=O)c2cc(Br)ccc2O)cc(c1)[S](F)(F)(F)(F)F
-Q0S SMILES_CANONICAL "OpenEye OEToolkits" 2.0.7                                                                CS(=O)(=O)c1cc(cc(c1)S(F)(F)(F)(F)F)NS(=O)(=O)c2cc(ccc2O)Br
-Q0S           SMILES "OpenEye OEToolkits" 2.0.7                                                                CS(=O)(=O)c1cc(cc(c1)S(F)(F)(F)(F)F)NS(=O)(=O)c2cc(ccc2O)Br
+Q0S  SMILES            ACDLabs               12.01  "c1(cc(ccc1O)Br)S(Nc2cc(S(F)(F)(F)(F)F)cc(c2)S(C)(=O)=O)(=O)=O"
+Q0S  InChI             InChI                 1.03   "InChI=1S/C13H11BrF5NO5S3/c1-26(22,23)10-5-9(6-11(7-10)28(15,16,17,18)19)20-27(24,25)13-4-8(14)2-3-12(13)21/h2-7,20-21H,1H3"
+Q0S  InChIKey          InChI                 1.03   GXKWWSXTDOWSFB-UHFFFAOYSA-N
+Q0S  SMILES_CANONICAL  CACTVS                3.385  "C[S](=O)(=O)c1cc(N[S](=O)(=O)c2cc(Br)ccc2O)cc(c1)[S](F)(F)(F)(F)F"
+Q0S  SMILES            CACTVS                3.385  "C[S](=O)(=O)c1cc(N[S](=O)(=O)c2cc(Br)ccc2O)cc(c1)[S](F)(F)(F)(F)F"
+Q0S  SMILES_CANONICAL  "OpenEye OEToolkits"  2.0.7  "CS(=O)(=O)c1cc(cc(c1)S(F)(F)(F)(F)F)NS(=O)(=O)c2cc(ccc2O)Br"
+Q0S  SMILES            "OpenEye OEToolkits"  2.0.7  "CS(=O)(=O)c1cc(cc(c1)S(F)(F)(F)(F)F)NS(=O)(=O)c2cc(ccc2O)Br"
 loop_
 _pdbx_chem_comp_description_generator.comp_id
 _pdbx_chem_comp_description_generator.program_name
 _pdbx_chem_comp_description_generator.program_version
 _pdbx_chem_comp_description_generator.descriptor
-Q0S acedrg               243         "dictionary generator"                  
-Q0S acedrg_database      11          "data source"                           
-Q0S rdkit                2017.03.2   "Chemoinformatics tool"
-Q0S refmac5              5.8.0238    "optimization tool"                     
+Q0S acedrg               272         "dictionary generator"                  
+Q0S acedrg_database      12          "data source"                           
+Q0S rdkit                2019.09.1   "Chemoinformatics tool"
+Q0S refmac5              5.8.0405    "optimization tool"                     


### PR DESCRIPTION
Recreated using Acedrg 272. When these monomers were generated, Acedrg did not support sulfur with octahedral geometry (D65/Q0S). PO2 looks unreal, but now it works to some extent.