### PR TITLE
add DNA-SER and DNA-TYR links

### DIFF
--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -36009,6 +36009,8 @@ _chem_link.mod_id_2
 _chem_link.group_comp_2
 _chem_link.name
 DG9-SER DG9 DG9m1 NON-POLYMER SER SERm1 peptide DG9-SER
+DNA-SER . DEL_OP3 DNA/RNA SER SERm1 peptide DNA-SER
+DNA-TYR . DEL_OP3 DNA/RNA TYR TYRmod5 peptide DNA-TYR
 SS . CYS-SS peptide . CYS-SS peptide SS-bridge
 disulf CYS CYS-SS peptide CYS CYS-SS peptide SS-bridge
 CYS-MPR CYS CYS-SS peptide MPR MPRm1 NON-POLYMER SS-bridge
@@ -36242,6 +36244,7 @@ LYSmod4 LYSINE LYS peptide
 PLPmod1 "PYRIDOXAL-5'-PHOSPHATE" PLP NON-POLYMER
 TRPmod1 TRYPTOPHAN TRP peptide
 TYRmod4 TYROSINE TYR peptide
+TYRmod5 TYROSINE TYR peptide
 NH2mod1 'AMINO GROUP                         ' NH2 NON-POLYMER
 CR8mod2 "2-[1-AMINO-2-(1H-IMIDAZOL-5-YL)ETHYL]-1-(CARBOXYMETHYL)-4-[(4-OXOCYCLOHEXA-2,5-DIEN-1-YLIDENE)METHYL]-1H-IMIDAZOL-5-OLATE" CR8 NON-POLYMER
 CROmod2 "{2-[(1R,2R)-1-amino-2-hydroxypropyl]-4-(4-hydroxybenzylidene)-5-oxo-4,5-dihydro-1H-imidazol-1-yl}acetic acid" CRO NON-POLYMER
@@ -36310,6 +36313,120 @@ _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
 DG9-SER 1 P2A 2 OG 1 O6A 1 O3 both
+
+data_link_DNA-SER
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+DNA-SER 1 P 2 OG SINGLE 1.607 0.0108
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+DNA-SER 1 OP1 1 P 2 OG 107.777 3.00
+DNA-SER 1 OP2 1 P 2 OG 107.777 3.00
+DNA-SER 1 "O5'" 1 P 2 OG 103.482 3.00
+DNA-SER 2 CB 2 OG 1 P 119.008 2.40
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+DNA-SER sp3_sp3_1 2 CB 2 OG 1 P 1 OP1 60.000 10.0 3
+DNA-SER sp3_sp3_2 2 CA 2 CB 2 OG 1 P 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+DNA-SER 1 P 1 "O5'" 2 OG 1 OP2 both
+
+data_link_DNA-TYR
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+DNA-TYR 1 P 2 OH SINGLE 1.618 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+DNA-TYR 1 OP1 1 P 2 OH 108.075 3.00
+DNA-TYR 1 OP2 1 P 2 OH 108.075 3.00
+DNA-TYR 1 "O5'" 1 P 2 OH 101.281 3.00
+DNA-TYR 2 CZ 2 OH 1 P 121.950 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+DNA-TYR sp3_sp3_1 1 OP1 1 P 2 OH 2 CZ 180.000 10.0 3
+DNA-TYR sp2_sp2_1 2 CE1 2 CZ 2 OH 1 P 180.000 5.0 2
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+DNA-TYR 1 P 1 "O5'" 2 OH 1 OP2 both
 
 data_link_SS
 loop_
@@ -47424,6 +47541,55 @@ TYRmod4 delete plan-1 HD2 0.020
 TYRmod4 delete plan-1 HE1 0.020
 TYRmod4 delete plan-1 HE2 0.020
 TYRmod4 delete plan-1 OH 0.020
+
+data_mod_TYRmod5
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+TYRmod5 delete HH . H H 0
+TYRmod5 change OH . O O 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+TYRmod5 delete OH HH single . . . .
+TYRmod5 change CZ OH single 1.410 0.0100 1.410 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+TYRmod5 delete CZ OH HH . .
+TYRmod5 change CE1 CZ CE2 121.469 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+TYRmod5 delete CE1 CZ OH HH . . . 0
 
 data_mod_NH2mod1
 loop_


### PR DESCRIPTION
For serine/tyrosine recombinases. Links were made by Acedrg 271 with
```
LINK: RES-NAME-1 DT ATOM-NAME-1 P RES-NAME-2 SER ATOM-NAME-2 OG DELETE ATOM OP3 1
```
and
```
LINK: RES-NAME-1 DT ATOM-NAME-1 P RES-NAME-2 TYR ATOM-NAME-2 OH DELETE ATOM OP3 1
```
and tested using 1zr4 and 3qx3, respectively.

`_chem_mod_tor.new_period` was manually changed to 0 from ".", as it caused an error in gemmi (just fixed https://github.com/project-gemmi/gemmi/commit/5302c7afef30eef6d48d3084c34b2dd557a398f9)