### PR TITLE
Update ETA.cif manually

### DIFF
--- a/e/ETA.cif
+++ b/e/ETA.cif
@@ -15,23 +15,24 @@ data_comp_ETA
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
 _chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-ETA     CA      C       CH2     0       -12.748     2.075       24.557      
-ETA     N       N       NT2     0       -12.926     1.318       23.316      
-ETA     CB      C       CH2     0       -12.913     3.560       24.350      
-ETA     O       O       OH1     0       -14.280     3.931       24.411      
-ETA     HA1     H       H       0       -11.853     1.896       24.914      
-ETA     HA2     H       H       0       -13.404     1.766       25.216      
-ETA     HN1     H       H       0       -12.940     0.447       23.492      
-ETA     HN2     H       H       0       -13.705     1.524       22.944      
-ETA     HB1     H       H       0       -12.548     3.812       23.480      
-ETA     HB2     H       H       0       -12.415     4.044       25.038      
-ETA     HO      H       H       0       -14.684     3.607       23.743      
+ETA  CA   CA     C       CH2     0       -12.748     2.075       24.557
+ETA  N    N      N       NT2     0       -12.926     1.318       23.316
+ETA  C    CB     C       CH2     0       -12.913     3.560       24.350
+ETA  O    O      O       OH1     0       -14.280     3.931       24.411
+ETA  HA1  HA1    H       H       0       -11.853     1.896       24.914
+ETA  HA2  HA2    H       H       0       -13.404     1.766       25.216
+ETA  H    HN1    H       H       0       -12.940     0.447       23.492
+ETA  H2   HN2    H       H       0       -13.705     1.524       22.944
+ETA  HB1  HB1    H       H       0       -12.548     3.812       23.480
+ETA  HB2  HB2    H       H       0       -12.415     4.044       25.038
+ETA  HO   HO     H       H       0       -14.684     3.607       23.743
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
@@ -43,14 +44,14 @@ _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
 ETA          CA           N      SINGLE       n     1.464  0.0200     1.464  0.0200
-ETA          CA          CB      SINGLE       n     1.509  0.0138     1.509  0.0138
-ETA          CB           O      SINGLE       n     1.417  0.0159     1.417  0.0159
+ETA          CA           C      SINGLE       n     1.509  0.0138     1.509  0.0138
+ETA           C           O      SINGLE       n     1.417  0.0159     1.417  0.0159
 ETA          CA         HA1      SINGLE       n     1.089  0.0100     0.980  0.0143
 ETA          CA         HA2      SINGLE       n     1.089  0.0100     0.980  0.0143
-ETA           N         HN1      SINGLE       n     1.036  0.0160     0.888  0.0200
-ETA           N         HN2      SINGLE       n     1.036  0.0160     0.888  0.0200
-ETA          CB         HB1      SINGLE       n     1.089  0.0100     0.977  0.0146
-ETA          CB         HB2      SINGLE       n     1.089  0.0100     0.977  0.0146
+ETA           N           H      SINGLE       n     1.036  0.0160     0.888  0.0200
+ETA           N          H2      SINGLE       n     1.036  0.0160     0.888  0.0200
+ETA           C         HB1      SINGLE       n     1.089  0.0100     0.977  0.0146
+ETA           C         HB2      SINGLE       n     1.089  0.0100     0.977  0.0146
 ETA           O          HO      SINGLE       n     0.970  0.0120     0.846  0.0200
 loop_
 _chem_comp_angle.comp_id
@@ -59,22 +60,22 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-ETA           N          CA          CB     111.883    2.59
+ETA           N          CA           C     111.883    2.59
 ETA           N          CA         HA1     108.870    1.50
 ETA           N          CA         HA2     108.870    1.50
-ETA          CB          CA         HA1     109.091    1.50
-ETA          CB          CA         HA2     109.091    1.50
+ETA           C          CA         HA1     109.091    1.50
+ETA           C          CA         HA2     109.091    1.50
 ETA         HA1          CA         HA2     107.873    1.50
-ETA          CA           N         HN1     109.962    3.00
-ETA          CA           N         HN2     109.962    3.00
-ETA         HN1           N         HN2     107.243    3.00
-ETA          CA          CB           O     111.180    1.88
-ETA          CA          CB         HB1     109.705    1.50
-ETA          CA          CB         HB2     109.705    1.50
-ETA           O          CB         HB1     109.500    1.50
-ETA           O          CB         HB2     109.500    1.50
-ETA         HB1          CB         HB2     108.121    1.50
-ETA          CB           O          HO     109.054    3.00
+ETA          CA           N           H     109.962    3.00
+ETA          CA           N          H2     109.962    3.00
+ETA           H           N          H2     107.243    3.00
+ETA          CA           C           O     111.180    1.88
+ETA          CA           C         HB1     109.705    1.50
+ETA          CA           C         HB2     109.705    1.50
+ETA           O           C         HB1     109.500    1.50
+ETA           O           C         HB2     109.500    1.50
+ETA         HB1           C         HB2     108.121    1.50
+ETA           C           O          HO     109.054    3.00
 loop_
 _chem_comp_tor.comp_id
 _chem_comp_tor.id
@@ -85,9 +86,9 @@ _chem_comp_tor.atom_id_4
 _chem_comp_tor.value_angle
 _chem_comp_tor.value_angle_esd
 _chem_comp_tor.period
-ETA             sp3_sp3_1          CB          CA           N         HN1     180.000    10.0     3
-ETA             sp3_sp3_7           N          CA          CB           O     180.000    10.0     3
-ETA            sp3_sp3_16          CA          CB           O          HO     180.000    10.0     3
+ETA             sp3_sp3_1           C          CA           N           H     180.000    10.0     3
+ETA             sp3_sp3_7           N          CA           C           O     180.000    10.0     3
+ETA            sp3_sp3_16          CA           C           O          HO     180.000    10.0     3
 loop_
 _pdbx_chem_comp_descriptor.comp_id
 _pdbx_chem_comp_descriptor.type


### PR DESCRIPTION
three atoms renamed (backbone remediation in CCD), added `_chem_comp_atom.alt_atom_id` for previous names

This is an example and proposal to use `_chem_comp_atom.alt_atom_id`, which is used in the CCD.

alt_atom_id could be used to automatically recognize and handle old atom names. In particular, names from before the backbone remediation that took place in November (it was announced on Monday).

Example test file from before the remediation:
ftp://snapshots.rcsb.org/all_pdb_files_20230102/al/pdb1alx.ent.gz
(it may work if a program takes into account alt_atom_id).