### PR TITLE
fix PRO _chem_comp_tree

### DIFF
--- a/p/PRO.cif
+++ b/p/PRO.cif
@@ -60,6 +60,7 @@ PRO C   CA  .   END
 PRO O   C   .   .
 PRO OXT C   .   .
 PRO H   N   .   .
+PRO H2  N   .   .
 PRO CD  N   .   ADD
 
 loop_


### PR DESCRIPTION
In #38, H2 atom was added to PRO, but _chem_comp_tree was not modified. This is needed by Refmac (while Refmacat is fine).