### PR TITLE
Add file links.cif

### DIFF
--- a/links_and_mods.cif
+++ b/links_and_mods.cif
@@ -1,0 +1,11929 @@
+data_link_list
+loop_
+_chem_link.id
+_chem_link.comp_id_1
+_chem_link.mod_id_1
+_chem_link.group_comp_1
+_chem_link.comp_id_2
+_chem_link.mod_id_2
+_chem_link.group_comp_2
+_chem_link.name
+DG9-SER DG9 DG9m1 NON-POLYMER SER SERm1 peptide DG9-SER
+DNA-SER . DEL_OP3 DNA/RNA SER SERm1 peptide DNA-SER
+DNA-TYR . DEL_OP3 DNA/RNA TYR TYRmod5 peptide DNA-TYR
+SS . CYS-SS peptide . CYS-SS peptide SS-bridge
+disulf CYS CYS-SS peptide CYS CYS-SS peptide SS-bridge
+CYS-MPR CYS CYS-SS peptide MPR MPRm1 NON-POLYMER SS-bridge
+TRANS . DEL-OXT peptide . DEL-HN1 peptide TRANS
+CIS . DEL-OXT peptide . DEL-HN1 peptide CIS
+PTRANS . DEL-OXT peptide . DEL-HNP P-peptide PTRANS
+PCIS . DEL-OXT peptide . DEL-HNP P-peptide PCIS
+NMTRANS . DEL-OXT1 peptide . DEL-NMH M-peptide NMTRANS
+NMCIS . DEL-OXT1 peptide . DEL-NMH M-peptide NMCIS
+pept-SUI . DEL-OXT peptide SUI SUImod1 NON-POLYMER pept-SUI
+SUI-pept SUI SUImod2 NON-POLYMER . DEL-HN1 peptide SUI-pept
+gap . . . . . . gap-link
+p . DEL_HO3p DNA/RNA . DEL_OP3 DNA/RNA default-DNA/RNA-link
+AA-RNA . DEL-OXT peptide . DEL_HO3p DNA/RNA aminoacyl-RNA
+RNA-F86 . DEL_HO3p DNA/RNA F86 F86m1 NON-POLYMER RNA-F86
+FOR_C-N FOR FORm1 NON-POLYMER . DEL-HN1 peptide bond_FOR-C_=_N-peptide
+FOR-LYS LYS LYSmod3 peptide FOR FORm1 NON-POLYMER FOR-LYS
+ACE_C-N ACE ACEmod NON-POLYMER . DEL-HN1 peptide bond_ACE-C_=_N_peptide
+IVA_C-N IVA IVAm1 NON-POLYMER . DEL-HN1 peptide bond_IVA-C_=_N-peptide
+BOC_C-N BOC BOCm1 NON-POLYMER . DEL-HN1 peptide bond_BOC-C_=_N-peptide
+NME_N-C . DEL-OXT peptide NME NMEm1 NON-POLYMER bond_NME-N_=_C-peptide
+ALPHA1-1 . DEL-HO1 pyranose . DEL-O1 pyranose glycosidic_bond_alpha1-1
+ALPHA1-2 . DEL-HO2 pyranose . DEL-O1 pyranose glycosidic_bond_alpha1-2
+ALPHA1-3 . DEL-HO3 pyranose . DEL-O1 pyranose glycosidic_bond_alpha1-3
+ALPHA2-3 . DEL-HO3 pyranose . DELk-O2 ketopyranose glycosidic_bond_alpha2-3
+ALPHA2-4 . DELk-HO4 ketopyranose . DELk-O2 ketopyranose ALPHA2-4
+ALPHA1-5 . DEL-HO5 ketopyranose . DEL-O1 pyranose ALPHA1-5
+ALPHA1-4 . DEL-HO4 pyranose . DEL-O1 pyranose glycosidic_bond_alpha1-4
+ALPHA1-6 . DEL-HO6 pyranose . DEL-O1 pyranose glycosidic_bond_alpha1-6
+ALPHA1-7 . DEL-HO7 pyranose . DEL-O1 pyranose glycosidic_bond_alpha1-7
+BETA1-2 . DEL-HO2 pyranose . DEL-O1 pyranose glycosidic_bond_beta1-2
+BETA1-3 . DEL-HO3 pyranose . DEL-O1 pyranose glycosidic_bond_beta1-3
+BETA2-3 . DEL-HO3 pyranose . DELk-O2 ketopyranose glycosidic_bond_beta2-3
+BETA2-4 . DELk-HO4 ketopyranose . DELk-O2 ketopyranose BETA2-4
+BETA1-5 . DEL-HO5 ketopyranose . DEL-O1 pyranose BETA1-5
+BETA1-4 . DEL-HO4 pyranose . DEL-O1 pyranose glycosidic_bond_beta1-4
+BETA1-6 . DEL-HO6 pyranose . DEL-O1 pyranose glycosidic_bond_beta1-6
+BETA1-7 . DEL-HO7 pyranose . DEL-O1 pyranose glycosidic_bond_beta1-7
+pyr-SER . DEL-O1 pyranose SER DEL-HG peptide bond_pyr-C1_=_SER-OG
+pyr-THR . DEL-O1 pyranose THR DEL-HG1 peptide bond_pyr-C1_=_THR-OG1
+pyr-ASN . DEL-O1 pyranose ASN DEL-HD22 peptide bond_pyr-C1_=_ASN-ND2
+ZN-CYS ZN . NON-POLYMER CYS CYSmod1 peptide bond_ZN_=_CYS-SG
+ZN-HISND ZN . NON-POLYMER HIS DEL-HD1 peptide bond_ZN_=_HIS-ND1
+ZN-HISNE ZN . NON-POLYMER HIS DEL-HE2 peptide bond_ZN_=_HIS-NE2
+HEC-CYS1 HEC HECmod1 NON-POLYMER CYS CYSmod1 peptide HEC_CAC-CYS1
+HEC-CYS2 HEC HECmod2 NON-POLYMER CYS CYSmod1 peptide HEC_CAB-CYS2
+FE-CYS FE . NON-POLYMER CYS CYSmod1 peptide bond_FE_=_CYS-SG
+FE-HISND FE . NON-POLYMER HIS DEL-HD1 peptide bond_FE_=_HIS-ND1
+FE-HISNE FE . NON-POLYMER HIS DEL-HE2 peptide bond_FE_=_HIS-NE2
+FES1-CYS FES . NON-POLYMER CYS CYSmod1 peptide bond_FES1_CYS-SG
+FES2-CYS FES . NON-POLYMER CYS CYSmod1 peptide bond_FES2_CYS-SG
+SF41-CYS SF4 . NON-POLYMER CYS CYSmod1 peptide bond_SF41_CYS-SG
+SF42-CYS SF4 . NON-POLYMER CYS CYSmod1 peptide bond_SF42_CYS-SG
+SF43-CYS SF4 . NON-POLYMER CYS CYSmod1 peptide bond_SF43_CYS-SG
+SF44-CYS SF4 . NON-POLYMER CYS CYSmod1 peptide bond_SF44_CYS-SG
+SF31-CYS SF3 . NON-POLYMER CYS CYSmod1 peptide bond_SF31_CYS-SG
+SF37-CYS SF3 . NON-POLYMER CYS CYSmod1 peptide bond_SF37_CYS-SG
+SF33-CYS SF3 . NON-POLYMER CYS CYSmod1 peptide bond_SF33_CYS-SG
+SF34-CYS SF3 . NON-POLYMER CYS CYSmod1 peptide bond_SF34_CYS-SG
+ACYSNN ACY ACYmod NON-POLYMER SNN SNNmod1 NON-POLYMER 'ACYSNN'
+pept-SNN . DEL-OXT peptide SNN SNNmod NON-POLYMER 'pept-SNN'
+TPN-TPN TPN TPNmodC NON-POLYMER TPN TPNmodN NON-POLYMER TPN-TPN
+pept-ORN . DEL-OXT peptide ORN ORN-NE peptide pept-ORN
+symmetry . . . . . . dummy_link
+02J-pept 02J 02Jmod1 NON-POLYMER . DEL-HN1 peptide 02J-pept
+ALPHA2-6 . DEL-HO6 pyranose . DELk-O2 ketopyranose ALPHA2-6
+ALPHA2-8 . DEL-HO8 ketopyranose . DELk-O2 ketopyranose ALPHA2-8
+BETA2-6 . DEL-HO6 pyranose . DELk-O2 ketopyranose BETA2-6
+BETA2-8 . DEL-HO8 ketopyranose . DELk-O2 ketopyranose BETA2-8
+CYS-BME CYS CYSmod1 peptide BME BMEmod1 NON-POLYMER CYS-BME
+CR8-pept CR8 CR8mod1 NON-POLYMER . DEL-HN1 peptide CR8-pept
+CRO-pept CRO CROmod1 NON-POLYMER . DEL-HN1 peptide CRO-pept
+CYS-CYC CYS CYSmod1 peptide CYC CYCmod1 NON-POLYMER CYS-CYC
+CYS-FAD CYS CYSmod2 peptide FAD FADmod1 NON-POLYMER CYS-FAD
+CYS-PEB CYS CYSmod1 peptide PEB PEBmod1 NON-POLYMER CYS-PEB
+Ddisul DCY CYS-SS peptide DCY CYS-SS peptide Ddisul
+HIS-FAD1 HIS HISmod1 peptide FAD FADmod2 NON-POLYMER HIS-FAD1
+HIS-FAD2 HIS HISmod2 peptide FAD FADmod3 NON-POLYMER HIS-FAD2
+GTP-p GTP GTPmod1 NON-POLYMER . DEL_OP3 DNA/RNA GTP-p
+GYC-pept GYC GYCmod1 NON-POLYMER . DEL-HN1 peptide GYC-pept
+CYS-HEMB CYS CYSmod1 peptide HEM HEMmod2 NON-POLYMER CYS-HEMB
+CYS-HEMC CYS CYSmod1 peptide HEM HEMmod3 NON-POLYMER CYS-HEMC
+HIS_TYR1 HIS HISmod1 peptide TYR TYRmod1 peptide HIS_TYR1
+HIS_TYR2 HIS HISmod3 peptide TYR TYRmod2 peptide HIS_TYR2
+IAS-pept IAS IASmod1 NON-POLYMER . DEL-HN1 peptide IAS-pept
+pept-IAS . DEL-OXT peptide IAS DEL-HN1 NON-POLYMER pept-IAS
+LYS-CYS LYS LYSmod1 peptide CYS CYSmod1 peptide LYS-CYS
+LYS-RET LYS LYSmod2 peptide RET RETmod1 NON-POLYMER LYS-RET
+LYS-ASN LYS LYSmod3 peptide ASN ASNmod1 peptide LYS-ASN
+MDO-pept MDO MDOmod1 NON-POLYMER . DEL-HN1 peptide MDO-pept
+MET-TYR MET METmod1 peptide TYR TYRmod3 peptide MET-TYR
+NRQ-pept NRQ NRQmod1 NON-POLYMER . DEL-HN1 peptide NRQ-pept
+PJE-010 PJE PJEmod1 NON-POLYMER 010 010mod1 NON-POLYMER PJE-010
+PJE-CYS PJE PJEmod2 NON-POLYMER CYS CYSmod1 peptide PJE-CYS
+PJE-LEU PJE PJEmod3 NON-POLYMER LEU LEUmod1 peptide PJE-LEU
+LYS-PLP LYS LYSmod4 peptide PLP PLPmod1 NON-POLYMER LYS-PLP
+TRP-TYR TRP TRPmod1 peptide TYR TYRmod4 peptide TRP-TYR
+pep-NH2 . DEL-OXT peptide NH2 NH2mod1 NON-POLYMER pep-NH2
+pept-CR8 . DEL-OXT pept CR8 CR8mod2 NON-POLYMER pept-CR8
+pept-CRO . DEL-OXT peptide CRO CROmod2 NON-POLYMER pept-CRO
+pept-GYC . DEL-OXT peptide GYC GYCmod2 NON-POLYMER pept-GYC
+pept-NRQ . DEL-OXT peptide NRQ NRQmod2 NON-POLYMER pept-NRQ
+pept-LYS . DEL-OXT pept LYS LYSmod5 peptide pept-LYS
+pept-MDO . DEL-OXT peptide MDO MDOmod2 NON-POLYMER pept-MDO
+MS6-pept MS6 MS6mod1 NON-POLYMER . MS6mod2 peptide MS6-pept
+pept-MS6 . DEL-OXT peptide MS6 MS6delNH NON-POLYMER pept-MS6
+
+data_mod_list
+loop_
+_chem_mod.id
+_chem_mod.name
+_chem_mod.comp_id
+_chem_mod.group_id
+DG9m1 DG9 DG9 NON-POLYMER
+SERm1 SERINE SER peptide
+CYS-SS HG-deletete CYS peptide
+CYSmod1 CYS-HG-delete_with_atom_type CYS peptide
+MPRm1 MPR-HS3-delete_with_atom_type MPR NON-POLYMER
+FORm1 FOR-H2-delete FOR NON-POLYMER
+NH3 NH3-terminus . peptide
+NH1 NH1-terminus . peptide
+NH2 NH2-terminus_for_proline . peptide
+ACEmod ACEmod-for_ACE_PEP_link ACE NON-POLYMER
+NH2N NH2-terminus_proline_type_with_CN . peptide
+COO COO-terminus . peptide
+AA-STAND AA_to_residue_modification . peptide
+AA-STPRO AA_to_residue_modification_for_proline . peptide
+NA-STAND DNA/RNA_to_residue_modification . DNA/RNA
+5*END DNA/RNA-5*-terminus . DNA/RNA
+3*END DNA/RNA-3*-terminus . DNA/RNA
+p5*END DNA/RNA-p5*-terminus . DNA/RNA
+p3*END DNA/RNA-p3*-terminus . DNA/RNA
+DEL_OP3 DN/RNA-OP3-delete . DNA/RNA
+DEL_HO3p DNA/RNA-OP3-delete . DNA/RNA
+F86m1 "[(2~{R},3~{S},4~{R},5~{R})-5-(4-azanylpyrrolo[2,1-f][1,2,4]triazin-7-yl)-5-cyano-3,4-bis(oxidanyl)oxolan-2-yl]methyl dihydrogen phosphate" F86 NON-POLYMER
+FOR-N N-terminus_of_formyl . .
+FOR-C C-terminus_of_formyl . .
+G-N2 delete_N2_from_guanosine . DNA/RNA
+DEL-O1 delete_O1_from_saccharide . pyranose
+DELk-O2 delete_O2_from_saccharide . ketopyranose
+DEL-HO1 delete_HO1_from_pyranose . pyranose
+DEL-HO2 delete_HO2_from_saccharide . pyranose
+DEL-HO3 delete_HO3_from_saccharide . pyranose
+DEL-HO4 delete_HO4_from_saccharide . pyranose
+DELk-HO4 delete_HO4_from_saccharide . ketopyranose
+DEL-HO5 delete_HO4_from_saccharide . ketopyranose
+DEL-HO6 delete_HO6_from_saccharide . pyranose
+DEL-HO7 delete_HO7_from_sacharide . pyranose
+DEL-HO8 delete_HO4_from_saccharide . ketopyranose
+DEL-HD1 delete_HD1_from_HIS HIS peptide
+DEL-HE2 delete_HE2_from_HIS HIS peptide
+DEL-OXT delete_OXT_from_peptide . peptide
+DEL-OXT1 delete_OXT_from_peptide . peptide
+DEL-HN1 delete_Hs_from_peptide . peptide
+DEL-NMH delete_Hs_from_NMpeptide . peptide
+DEL-HNP delete_Hs_from_peptide . peptide
+SUImod1 "(3-AMINO-2,5-DIOXO-1-PYRROLIDINYL)ACETIC ACID" SUI NON-POLYMER
+SUImod2 "(3-AMINO-2,5-DIOXO-1-PYRROLIDINYL)ACETIC ACID" SUI NON-POLYMER
+SUG-b-L change_sugar_to_beta_L . pyranose
+SUG-a-D change_sugar_to_alpha_D . pyranose
+SUG-b-D change_sugar_to_beta_D . pyranose
+SUG-a-L change_sugar_to_alpha_L . pyranose
+O1MET O1_metyl_of_sugar . pyranose
+PEPT-D change_peptide_to_D . peptide
+1MA N1-metyl_of_adenosine . DNA/RNA
+1MG N1-metyl_of_guanosine . DNA/RNA
+2MG N2-metyl_of_guanosine . DNA/RNA
+M2G N2-dimetyl_of_guanosine . DNA/RNA
+O2*MET O2*_metyl . DNA/RNA
+C5MET C5_metyl . DNA/RNA
+N7MET N7_metyl . DNA/RNA
+RNA-O2* delete_O2*_from_RNA . DNA/RNA
+XYS-O1 delete_O1_from_XYS . .
+B2C replace_B_to_C . peptide
+B2C_D replace_B_to_C_for_D-peptide . peptide
+RENAME change_monomer"s_name . .
+TERMINUS chain_terminus_without_modification . .
+DEL-HD22 delete_HD22_from_ASN ASN peptide
+DEL-HG delete_HG_from_SER SER peptide
+DEL-HG1 delete_HG1_from_THR THR peptide
+ACYmod 'ACYmod' ACY NON-POLYMER
+IVAm1 'IVA_delOXT' IVA NON-POLYMER
+BOCm1 'BOC_delO3' BOC NON-POLYMER
+NMEm1 'NME_delH' NME NON-POLYMER
+SNNmod 'SNNmod' SNN NON-POLYMER
+SNNmod1 'SNNmod' SNN NON-POLYMER
+TPNmodC 2-AMINOETHYLGLYCINE-CARBONYLMETHYLEN TPN NON-POLYMER
+TPNmodN 2-AMINOETHYLGLYCINE-CARBONYLMETHYLEN TPN NON-POLYMER
+ORN-NE 'ORNITHINE                           ' ORN peptide
+HECmod1 'HEME C CAB-C3B bond order           ' HEC NON-POLYMER
+HECmod2 'HEME C CAC-C3C bond order           ' HEC NON-POLYMER
+02Jmod1 "5-methyl-1,2-oxazole-3-carboxylic acid" 02J NON-POLYMER
+BMEmod1 BETA-MERCAPTOETHANOL BME NON-POLYMER
+CR8mod1 "2-[1-AMINO-2-(1H-IMIDAZOL-5-YL)ETHYL]-1-(CARBOXYMETHYL)-4-[(4-OXOCYCLOHEXA-2,5-DIEN-1-YLIDENE)METHYL]-1H-IMIDAZOL-5-OLATE" CR8 NON-POLYMER
+CROmod1 "{2-[(1R,2R)-1-amino-2-hydroxypropyl]-4-(4-hydroxybenzylidene)-5-oxo-4,5-dihydro-1H-imidazol-1-yl}acetic acid" CRO NON-POLYMER
+CYCmod1 PHYCOCYANOBILIN CYC NON-POLYMER
+FADmod1 "FLAVIN-ADENINE DINUCLEOTIDE" FAD NON-POLYMER
+PEBmod1 PHYCOERYTHROBILIN PEB NON-POLYMER
+HISmod1 HISTIDINE HIS peptide
+FADmod2 "FLAVIN-ADENINE DINUCLEOTIDE" FAD NON-POLYMER
+HISmod2 HISTIDINE HIS peptide
+FADmod3 "FLAVIN-ADENINE DINUCLEOTIDE" FAD NON-POLYMER
+GTPmod1 "GUANOSINE-5'-TRIPHOSPHATE" GTP NON-POLYMER
+GYCmod1 "[(4Z)-2-[(1R)-1-AMINO-2-MERCAPTOETHYL]-4-(4-HYDROXYBENZYLIDENE)-5-OXO-4,5-DIHYDRO-1H-IMIDAZOL-1-YL]ACETIC ACID" GYC NON-POLYMER
+HEMmod2 "PROTOPORPHYRIN IX CONTAINING FE" HEM NON-POLYMER
+HEMmod3 "PROTOPORPHYRIN IX CONTAINING FE" HEM NON-POLYMER
+TYRmod1 TYROSINE TYR peptide
+HISmod3 HISTIDINE HIS peptide
+TYRmod2 TYROSINE TYR peptide
+IASmod1 "BETA-L-ASPARTIC ACID" IAS NON-POLYMER
+LYSmod1 LYSINE LYS peptide
+CYSmod2 CYSTEINE CYS peptide
+LYSmod2 LYSINE LYS peptide
+RETmod1 RETINAL RET NON-POLYMER
+LYSmod3 LYSINE LYS peptide
+ASNmod1 ASPARAGINE ASN peptide
+MDOmod1 "{2-[(1S)-1-aminoethyl]-4-methylidene-5-oxo-4,5-dihydro-1H-imidazol-1-yl}acetic acid" MDO NON-POLYMER
+METmod1 METHIONINE MET peptide
+TYRmod3 TYROSINE TYR peptide
+NRQmod1 "{(4Z)-4-(4-hydroxybenzylidene)-2-[3-(methylthio)propanimidoyl]-5-oxo-4,5-dihydro-1H-imidazol-1-yl}acetic acid" NRQ NON-POLYMER
+PJEmod1 "(E,4S)-4-azanyl-5-[(3S)-2-oxidanylidenepyrrolidin-3-yl]pent-2-enoic acid" PJE NON-POLYMER
+010mod1 phenylmethanol 010 NON-POLYMER
+PJEmod2 "(E,4S)-4-azanyl-5-[(3S)-2-oxidanylidenepyrrolidin-3-yl]pent-2-enoic acid" PJE NON-POLYMER
+PJEmod3 "(E,4S)-4-azanyl-5-[(3S)-2-oxidanylidenepyrrolidin-3-yl]pent-2-enoic acid" PJE NON-POLYMER
+LEUmod1 LEUCINE LEU peptide
+LYSmod4 LYSINE LYS peptide
+PLPmod1 "PYRIDOXAL-5'-PHOSPHATE" PLP NON-POLYMER
+TRPmod1 TRYPTOPHAN TRP peptide
+TYRmod4 TYROSINE TYR peptide
+TYRmod5 TYROSINE TYR peptide
+NH2mod1 'AMINO GROUP                         ' NH2 NON-POLYMER
+CR8mod2 "2-[1-AMINO-2-(1H-IMIDAZOL-5-YL)ETHYL]-1-(CARBOXYMETHYL)-4-[(4-OXOCYCLOHEXA-2,5-DIEN-1-YLIDENE)METHYL]-1H-IMIDAZOL-5-OLATE" CR8 NON-POLYMER
+CROmod2 "{2-[(1R,2R)-1-amino-2-hydroxypropyl]-4-(4-hydroxybenzylidene)-5-oxo-4,5-dihydro-1H-imidazol-1-yl}acetic acid" CRO NON-POLYMER
+GYCmod2 "[(4Z)-2-[(1R)-1-AMINO-2-MERCAPTOETHYL]-4-(4-HYDROXYBENZYLIDENE)-5-OXO-4,5-DIHYDRO-1H-IMIDAZOL-1-YL]ACETIC ACID" GYC NON-POLYMER
+NRQmod2 "{(4Z)-4-(4-hydroxybenzylidene)-2-[3-(methylthio)propanimidoyl]-5-oxo-4,5-dihydro-1H-imidazol-1-yl}acetic acid" NRQ NON-POLYMER
+LYSmod5 LYSINE LYS peptide
+MDOmod2 "{2-[(1S)-1-aminoethyl]-4-methylidene-5-oxo-4,5-dihydro-1H-imidazol-1-yl}acetic acid" MDO NON-POLYMER
+MS6mod1 DEL-OXT_equiv_for_MS6-pept MS6 NON-POLYMER
+MS6mod2 DEL-HN1_equiv_for_MS6-pept . peptide
+MS6delNH MS6_for_pept MS6 NON-POLYMER
+
+data_link_DG9-SER
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+DG9-SER 1 P2A 2 OG SINGLE 1.607 0.0108
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+DG9-SER 1 O3 1 P2A 2 OG 107.777 3.00
+DG9-SER 1 O4A 1 P2A 2 OG 107.777 3.00
+DG9-SER 1 O6A 1 P2A 2 OG 103.482 3.00
+DG9-SER 2 CB 2 OG 1 P2A 119.008 2.40
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+DG9-SER sp3_sp3_1 2 CB 2 OG 1 P2A 1 O3 180.000 10.0 3
+DG9-SER sp3_sp3_2 2 CA 2 CB 2 OG 1 P2A 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+DG9-SER 1 P2A 1 O6A 1 O3 2 OG both
+
+data_link_DNA-SER
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+DNA-SER 1 P 2 OG SINGLE 1.607 0.0108
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+DNA-SER 1 OP1 1 P 2 OG 107.777 3.00
+DNA-SER 1 OP2 1 P 2 OG 107.777 3.00
+DNA-SER 1 "O5'" 1 P 2 OG 103.482 3.00
+DNA-SER 2 CB 2 OG 1 P 119.008 2.40
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+DNA-SER sp3_sp3_1 2 CB 2 OG 1 P 1 OP1 60.000 10.0 3
+DNA-SER sp3_sp3_2 2 CA 2 CB 2 OG 1 P 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+DNA-SER 1 P 1 "O5'" 2 OG 1 OP2 both
+
+data_link_DNA-TYR
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+DNA-TYR 1 P 2 OH SINGLE 1.618 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+DNA-TYR 1 OP1 1 P 2 OH 108.075 3.00
+DNA-TYR 1 OP2 1 P 2 OH 108.075 3.00
+DNA-TYR 1 "O5'" 1 P 2 OH 101.281 3.00
+DNA-TYR 2 CZ 2 OH 1 P 121.950 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+DNA-TYR sp3_sp3_1 1 OP1 1 P 2 OH 2 CZ 180.000 10.0 3
+DNA-TYR sp2_sp2_1 2 CE1 2 CZ 2 OH 1 P 180.000 5.0 2
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+DNA-TYR 1 P 1 "O5'" 2 OH 1 OP2 both
+
+data_link_SS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SS 1 SG 2 SG single 2.031 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SS 1 CB 1 SG 2 SG 103.800 1.800
+SS 1 SG 2 SG 2 CB 103.800 1.800
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+SS ss 1 CB 1 SG 2 SG 2 CB 90.00 10.0 2
+
+data_link_disulf
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+disulf 1 SG 2 SG single 2.031 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+disulf 1 CB 1 SG 2 SG 103.800 1.800
+disulf 1 SG 2 SG 2 CB 103.800 1.800
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+disulf ss 1 CB 1 SG 2 SG 2 CB 90.00 10.0 2
+
+data_link_CYS-MPR
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CYS-MPR 1 SG 2 S3 SINGLE 2.032 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CYS-MPR 1 CB 1 SG 2 S3 103.477 2.39
+CYS-MPR 2 C3 2 S3 1 SG 103.834 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CYS-MPR sp3_sp3_1 2 C3 2 S3 1 SG 1 CB 180.000 10.0 3
+CYS-MPR sp3_sp3_2 2 C2 2 C3 2 S3 1 SG 180.000 10.0 3
+CYS-MPR sp3_sp3_3 1 CA 1 CB 1 SG 2 S3 180.000 10.0 3
+
+data_link_TRANS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+TRANS 1 C 2 N SINGLE 1.337 0.011
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+TRANS 1 CA 1 C 2 N 115.917 1.50
+TRANS 1 O 1 C 2 N 123.469 1.50
+TRANS 1 C 2 N 2 CA 122.095 1.76
+TRANS 1 C 2 N 2 H 119.176 1.83
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+TRANS psi 1 N 1 CA 1 C 2 N 160.00 30.0 2
+TRANS omega 1 CA 1 C 2 N 2 CA 180.00 5.0 0
+TRANS phi 1 C 2 N 2 CA 2 C 60.00 20.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+TRANS plan-1 1 CA 0.020
+TRANS plan-1 1 C 0.020
+TRANS plan-1 2 N 0.020
+TRANS plan-1 1 O 0.020
+TRANS plan-2 2 CA 0.020
+TRANS plan-2 1 C 0.020
+TRANS plan-2 2 H 0.020
+TRANS plan-2 2 N 0.020
+
+data_link_CIS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CIS 1 C 2 N SINGLE 1.337 0.011
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CIS 1 CA 1 C 2 N 115.917 1.50
+CIS 1 O 1 C 2 N 123.469 1.50
+CIS 1 C 2 N 2 CA 122.095 1.76
+CIS 1 C 2 N 2 H 119.176 1.83
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CIS psi 1 N 1 CA 1 C 2 N 160.00 30.0 2
+CIS omega 1 CA 1 C 2 N 2 CA 0.00 5.0 0
+CIS phi 1 C 2 N 2 CA 2 C 60.00 20.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+CIS plan-1 1 CA 0.020
+CIS plan-1 1 C 0.020
+CIS plan-1 2 N 0.020
+CIS plan-1 1 O 0.020
+CIS plan-2 2 CA 0.020
+CIS plan-2 1 C 0.020
+CIS plan-2 2 H 0.020
+CIS plan-2 2 N 0.020
+
+data_link_PTRANS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+PTRANS 1 C 2 N SINGLE 1.352 0.010
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+PTRANS 1 CA 1 C 2 N 118.415 1.50
+PTRANS 1 O 1 C 2 N 121.016 1.53
+PTRANS 2 CA 2 N 1 C 120.469 1.50
+PTRANS 2 CD 2 N 1 C 124.005 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+PTRANS psi 1 N 1 CA 1 C 2 N 160.00 30.0 2
+PTRANS omega 1 CA 1 C 2 N 2 CA 180.00 5.0 0
+PTRANS phi 1 C 2 N 2 CA 2 C 60.00 20.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+PTRANS plan-1 1 CA 0.020
+PTRANS plan-1 1 C 0.020
+PTRANS plan-1 2 N 0.020
+PTRANS plan-1 1 O 0.020
+PTRANS plan-2 1 C .020
+PTRANS plan-2 2 N .020
+PTRANS plan-2 2 CA .020
+PTRANS plan-2 2 CD .020
+
+data_link_PCIS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+PCIS 1 C 2 N SINGLE 1.352 0.010
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+PCIS 1 CA 1 C 2 N 118.415 1.50
+PCIS 1 O 1 C 2 N 121.016 1.53
+PCIS 2 CA 2 N 1 C 120.469 1.50
+PCIS 2 CD 2 N 1 C 124.005 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+PCIS psi 1 N 1 CA 1 C 2 N 160.00 30.0 2
+PCIS omega 1 CA 1 C 2 N 2 CA 0.00 5.0 0
+PCIS phi 1 C 2 N 2 CA 2 C 60.00 20.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+PCIS plan-1 1 CA 0.020
+PCIS plan-1 1 C 0.020
+PCIS plan-1 2 N 0.020
+PCIS plan-1 1 O 0.020
+PCIS plan-2 1 C .020
+PCIS plan-2 2 N .020
+PCIS plan-2 2 CA .020
+PCIS plan-2 2 CD .020
+
+data_link_NMTRANS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+NMTRANS 1 C 2 N SINGLE 1.346 0.020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+NMTRANS 1 CA 1 C 2 N 118.492 1.50
+NMTRANS 1 O 1 C 2 N 121.426 2.26
+NMTRANS 2 CA 2 N 1 C 121.862 2.35
+NMTRANS 2 CN 2 N 1 C 121.178 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+NMTRANS psi 1 N 1 CA 1 C 2 N 160.00 30.0 2
+NMTRANS omega 1 CA 1 C 2 N 2 CA 180.00 5.0 0
+NMTRANS phi 1 C 2 N 2 CA 2 C 60.00 20.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+NMTRANS plan-2 1 CA 0.020
+NMTRANS plan-2 1 C 0.020
+NMTRANS plan-2 2 N 0.020
+NMTRANS plan-2 1 O 0.020
+NMTRANS plan-3 2 CA 0.020
+NMTRANS plan-3 2 CN 0.020
+NMTRANS plan-3 1 C 0.020
+NMTRANS plan-3 2 N 0.020
+
+data_link_NMCIS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+NMCIS 1 C 2 N single 1.329 .014
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+NMCIS 1 O 1 C 2 N 123.000 1.600
+NMCIS 1 CA 1 C 2 N 116.200 2.000
+NMCIS 1 C 2 N 2 CN 124.300 3.000
+NMCIS 1 C 2 N 2 CA 121.700 1.800
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+NMCIS psi 1 N 1 CA 1 C 2 N 160.00 30.0 2
+NMCIS omega 1 CA 1 C 2 N 2 CA .00 5.0 0
+NMCIS phi 1 C 2 N 2 CA 2 C 60.00 20.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+NMCIS plane1 1 CA .020
+NMCIS plane1 1 C .020
+NMCIS plane1 1 O .020
+NMCIS plane1 2 N .020
+NMCIS plane2 1 C .050
+NMCIS plane2 2 N .050
+NMCIS plane2 2 CA .050
+NMCIS plane2 2 CN .050
+
+data_link_pept-SUI
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-SUI 1 C 2 N SINGLE 1.338 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-SUI 1 CA 1 C 2 N 117.912 3.00
+pept-SUI 1 O 1 C 2 N 123.381 1.50
+pept-SUI 2 CA 2 N 1 C 121.847 1.50
+pept-SUI 1 C 2 N 2 H 118.403 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-SUI sp2_sp2_1 1 CA 1 C 2 N 2 CA 180.000 5 2
+pept-SUI sp2_sp3_1 1 C 2 N 2 CA 2 CB 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-SUI plan-1 1 CA 0.020
+pept-SUI plan-1 1 C 0.020
+pept-SUI plan-1 2 N 0.020
+pept-SUI plan-1 1 O 0.020
+pept-SUI plan-2 2 CA 0.020
+pept-SUI plan-2 1 C 0.020
+pept-SUI plan-2 2 H 0.020
+pept-SUI plan-2 2 N 0.020
+
+data_link_SUI-pept
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SUI-pept 1 C 2 N SINGLE 1.339 0.0146
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SUI-pept 1 C2A 1 C 2 N 115.222 3.00
+SUI-pept 1 O 1 C 2 N 123.211 1.64
+SUI-pept 2 CA 2 N 1 C 121.976 2.97
+SUI-pept 1 C 2 N 2 H 119.006 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+SUI-pept sp2_sp2_1 1 C2A 1 C 2 N 2 CA 180.000 5 2
+SUI-pept sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+SUI-pept plan-4 1 C 0.020
+SUI-pept plan-4 1 C2A 0.020
+SUI-pept plan-4 2 N 0.020
+SUI-pept plan-4 1 O 0.020
+SUI-pept plan-5 1 C 0.020
+SUI-pept plan-5 2 CA 0.020
+SUI-pept plan-5 2 H 0.020
+SUI-pept plan-5 2 N 0.020
+
+data_link_gap
+
+data_link_p
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+p 1 "O3'" 2 P SINGLE 1.607 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+p 1 "C3'" 1 "O3'" 2 P 121.082 1.50
+p 2 OP1 2 P 1 "O3'" 109.493 3.00
+p 2 OP2 2 P 1 "O3'" 109.493 3.00
+p 2 "O5'" 2 P 1 "O3'" 100.661 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+p zeta 1 "C3'" 1 "O3'" 2 P 2 "O5'" 60.000 10.00 3
+p epsilon 1 "C4'" 1 "C3'" 1 "O3'" 2 P 180.000 10.00 3
+p alpha 1 "O3'" 2 "P" 2 "O5'" 2 "C5'" 180.000 10.00 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+p 2 P 2 "O5'" 1 "O3'" 2 OP2 both
+
+data_link_AA-RNA
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+AA-RNA 1 C 2 "O3'" SINGLE 1.334 0.0128
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+AA-RNA 1 CA 1 C 2 "O3'" 111.770 3.00
+AA-RNA 1 O 1 C 2 "O3'" 123.273 1.50
+AA-RNA 2 "C3'" 2 "O3'" 1 C 116.978 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+AA-RNA sp2_sp2_1 1 CA 1 C 2 "O3'" 2 "C3'" 180.000 5.0 2
+AA-RNA sp3_sp3_1 2 "C4'" 2 "C3'" 2 "O3'" 1 C 180.000 10.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+AA-RNA plan-1 1 CA 0.020
+AA-RNA plan-1 1 C 0.020
+AA-RNA plan-1 2 "O3'" 0.020
+AA-RNA plan-1 1 O 0.020
+
+data_link_RNA-F86
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+RNA-F86 1 "O3'" 2 P1 SINGLE 1.607 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+RNA-F86 1 "C3'" 1 "O3'" 2 P1 121.082 1.50
+RNA-F86 2 O4 2 P1 1 "O3'" 100.661 3.00
+RNA-F86 2 O6 2 P1 1 "O3'" 109.493 3.00
+RNA-F86 2 O5 2 P1 1 "O3'" 109.493 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+RNA-F86 sp3_sp3_1 1 "C3'" 1 "O3'" 2 P1 2 O4 180.000 10.00 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+RNA-F86 2 P1 2 O4 1 "O3'" 2 O6 both
+
+data_link_FOR_C-N
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+FOR_C-N 1 C 2 N SINGLE 1.329 0.0194
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+FOR_C-N 1 O 1 C 2 N 125.587 1.50
+FOR_C-N 2 N 1 C 1 H1 116.011 3.00
+FOR_C-N 2 CA 2 N 1 C 122.076 3.00
+FOR_C-N 1 C 2 N 2 H 118.750 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+FOR_C-N sp2_sp2_1 1 O 1 C 2 N 2 CA 180.000 5.0 2
+FOR_C-N sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+FOR_C-N plan-1 1 C 0.020
+FOR_C-N plan-1 1 H1 0.020
+FOR_C-N plan-1 2 N 0.020
+FOR_C-N plan-1 1 O 0.020
+FOR_C-N plan-2 1 C 0.020
+FOR_C-N plan-2 2 CA 0.020
+FOR_C-N plan-2 2 H 0.020
+FOR_C-N plan-2 2 N 0.020
+
+data_link_FOR-LYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+FOR-LYS 1 NZ 2 C SINGLE 1.324 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+FOR-LYS 1 CE 1 NZ 2 C 122.923 1.50
+FOR-LYS 2 C 1 NZ 1 HZ1 118.674 3.00
+FOR-LYS 2 O 2 C 1 NZ 124.965 1.73
+FOR-LYS 1 NZ 2 C 2 H1 116.853 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+FOR-LYS sp2_sp2_1 2 O 2 C 1 NZ 1 CE 180.000 5 2
+FOR-LYS sp2_sp3_2 2 C 1 NZ 1 CE 1 CD 120.000 10.0 6
+FOR-LYS sp2_sp3_2 2 C 1 NZ 1 CE 1 CD 120.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+FOR-LYS plan-2 2 C 0.020
+FOR-LYS plan-2 1 CE 0.020
+FOR-LYS plan-2 1 HZ1 0.020
+FOR-LYS plan-2 1 NZ 0.020
+FOR-LYS plan-3 2 C 0.020
+FOR-LYS plan-3 2 H1 0.020
+FOR-LYS plan-3 1 NZ 0.020
+FOR-LYS plan-3 2 O 0.020
+
+data_link_ACE_C-N
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ACE_C-N 1 C 2 N single 1.329 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ACE_C-N 1 C 2 N 2 CA 121.700 3.000
+ACE_C-N 1 O 1 C 2 N 123.000 3.000
+ACE_C-N 1 CH3 1 C 2 N 116.200 3.000
+ACE_C-N 1 C 2 N 2 H 124.300 3.000
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ACE_C-N sp2_sp2_1 1 CH3 1 C 2 N 2 CA 180.00 5.0 2
+ACE_C-N phi 1 C 2 N 2 CA 2 C 60.00 20.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+ACE_C-N plane1 1 CH3 .020
+ACE_C-N plane1 1 C .020
+ACE_C-N plane1 1 O .020
+ACE_C-N plane1 2 N .020
+ACE_C-N plane2 1 C .020
+ACE_C-N plane2 2 N .020
+ACE_C-N plane2 2 CA .020
+ACE_C-N plane2 2 H .020
+
+data_link_IVA_C-N
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+IVA_C-N 1 C 2 N SINGLE 1.343 0.0101
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+IVA_C-N 1 CA 1 C 2 N 115.437 3.00
+IVA_C-N 1 O 1 C 2 N 122.517 1.50
+IVA_C-N 2 CA 2 N 1 C 122.000 2.97
+IVA_C-N 1 C 2 N 2 H 118.959 1.65
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+IVA_C-N sp2_sp2_1 1 CA 1 C 2 N 2 CA 180.000 5.0 2
+IVA_C-N sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+IVA_C-N plan-1 1 CA 0.020
+IVA_C-N plan-1 1 C 0.020
+IVA_C-N plan-1 2 N 0.020
+IVA_C-N plan-1 1 O 0.020
+IVA_C-N plan-2 2 CA 0.020
+IVA_C-N plan-2 1 C 0.020
+IVA_C-N plan-2 2 H 0.020
+IVA_C-N plan-2 2 N 0.020
+
+data_link_BOC_C-N
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BOC_C-N 1 C 2 N SINGLE 1.345 0.0115
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BOC_C-N 1 O1 1 C 2 N 124.509 1.50
+BOC_C-N 1 O2 1 C 2 N 109.945 1.50
+BOC_C-N 2 CA 2 N 1 C 121.285 3.00
+BOC_C-N 1 C 2 N 2 H 119.271 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BOC_C-N sp2_sp2_1 1 O1 1 C 2 N 2 CA 0.000 5.0 2
+BOC_C-N sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+BOC_C-N plan-1 1 C 0.020
+BOC_C-N plan-1 2 N 0.020
+BOC_C-N plan-1 1 O1 0.020
+BOC_C-N plan-1 1 O2 0.020
+BOC_C-N plan-2 2 CA 0.020
+BOC_C-N plan-2 1 C 0.020
+BOC_C-N plan-2 2 H 0.020
+BOC_C-N plan-2 2 N 0.020
+
+data_link_NME_N-C
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+NME_N-C 1 C 2 N SINGLE 1.330 0.0147
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+NME_N-C 1 CA 1 C 2 N 115.984 1.50
+NME_N-C 1 O 1 C 2 N 123.444 1.50
+NME_N-C 2 C 2 N 1 C 122.082 1.50
+NME_N-C 1 C 2 N 2 HN1 119.088 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+NME_N-C sp2_sp2_1 1 CA 1 C 2 N 2 C 180.000 5.0 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+NME_N-C plan-1 1 CA 0.020
+NME_N-C plan-1 1 C 0.020
+NME_N-C plan-1 2 N 0.020
+NME_N-C plan-1 1 O 0.020
+NME_N-C plan-2 2 C 0.020
+NME_N-C plan-2 1 C 0.020
+NME_N-C plan-2 2 HN1 0.020
+NME_N-C plan-2 2 N 0.020
+
+data_link_ALPHA1-1
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA1-1 1 O1 2 C1 SINGLE 1.396 0.0113
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA1-1 1 C1 1 O1 2 C1 114.138 3.00
+ALPHA1-1 2 C2 2 C1 1 O1 108.334 3.00
+ALPHA1-1 2 O5 2 C1 1 O1 111.067 2.58
+ALPHA1-1 1 O1 2 C1 2 H1 109.453 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA1-1 sp3_sp3_1 2 C2 2 C1 1 O1 1 C1 180.000 10.0 3
+ALPHA1-1 sp3_sp3_3 1 C2 1 C1 1 O1 2 C1 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA1-1 2 C1 2 O5 1 O1 2 C2 positive
+
+data_link_ALPHA1-2
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA1-2 1 O2 2 C1 SINGLE 1.393 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA1-2 1 C2 1 O2 2 C1 115.777 3.00
+ALPHA1-2 2 C2 2 C1 1 O2 108.448 3.00
+ALPHA1-2 2 O5 2 C1 1 O2 110.493 3.00
+ALPHA1-2 1 O2 2 C1 2 H1 109.294 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA1-2 sp3_sp3_1 2 C2 2 C1 1 O2 1 C2 180.000 10.0 3
+ALPHA1-2 sp3_sp3_2 2 O5 2 C1 1 O2 1 C2 60.000 10.0 3
+ALPHA1-2 sp3_sp3_3 1 C1 1 C2 1 O2 2 C1 180.000 10.0 3
+ALPHA1-2 sp3_sp3_4 1 C3 1 C2 1 O2 2 C1 60.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA1-2 2 C1 1 O2 2 O5 2 C2 negative
+
+data_link_ALPHA1-3
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA1-3 1 O3 2 C1 SINGLE 1.393 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA1-3 1 C3 1 O3 2 C1 114.436 2.55
+ALPHA1-3 2 C2 2 C1 1 O3 108.448 3.00
+ALPHA1-3 2 O5 2 C1 1 O3 110.493 3.00
+ALPHA1-3 1 O3 2 C1 2 H1 109.294 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA1-3 sp3_sp3_1 2 C2 2 C1 1 O3 1 C3 180.000 10.0 3
+ALPHA1-3 sp3_sp3_2 2 O5 2 C1 1 O3 1 C3 60.000 10.0 3
+ALPHA1-3 sp3_sp3_3 1 C2 1 C3 1 O3 2 C1 180.000 10.0 3
+ALPHA1-3 sp3_sp3_4 1 C4 1 C3 1 O3 2 C1 60.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA1-3 2 C1 2 O5 1 O3 2 C2 positive
+
+data_link_ALPHA2-3
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA2-3 1 O3 2 C2 SINGLE 1.424 0.0200
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA2-3 1 C3 1 O3 2 C2 116.671 3.00
+ALPHA2-3 2 C1 2 C2 1 O3 108.549 3.00
+ALPHA2-3 2 C3 2 C2 1 O3 109.292 3.00
+ALPHA2-3 2 O6 2 C2 1 O3 110.235 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA2-3 sp3_sp3_1 2 C1 2 C2 1 O3 1 C3 180.000 10.0 3
+ALPHA2-3 sp3_sp3_7 1 C4 1 C3 1 O3 2 C2 60.000 10.0 3
+ALPHA2-3 sp2_sp3_1 2 O1A 2 C1 2 C2 1 O3 -120.000 10.0 6
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA2-3 2 C2 2 O6 1 O3 2 C1 negative
+
+data_link_BETA2-3
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA2-3 1 O3 2 C2 SINGLE 1.424 0.0200
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA2-3 1 C3 1 O3 2 C2 116.671 3.00
+BETA2-3 2 C1 2 C2 1 O3 108.549 3.00
+BETA2-3 2 C3 2 C2 1 O3 109.292 3.00
+BETA2-3 2 O6 2 C2 1 O3 110.235 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA2-3 sp3_sp3_1 2 C1 2 C2 1 O3 1 C3 180.000 10.0 3
+BETA2-3 sp3_sp3_7 1 C4 1 C3 1 O3 2 C2 60.000 10.0 3
+BETA2-3 sp2_sp3_1 2 O1A 2 C1 2 C2 1 O3 -120.000 10.0 6
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA2-3 2 C2 2 O6 1 O3 2 C1 positive
+
+data_link_ALPHA1-4
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA1-4 1 O4 2 C1 SINGLE 1.393 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA1-4 1 C4 1 O4 2 C1 117.674 3.00
+ALPHA1-4 2 C2 2 C1 1 O4 108.448 3.00
+ALPHA1-4 2 O5 2 C1 1 O4 110.493 3.00
+ALPHA1-4 1 O4 2 C1 2 H1 109.294 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA1-4 sp3_sp3_1 2 C2 2 C1 1 O4 1 C4 180.000 10.0 3
+ALPHA1-4 sp3_sp3_2 2 O5 2 C1 1 O4 1 C4 60.000 10.0 3
+ALPHA1-4 sp3_sp3_3 1 C3 1 C4 1 O4 2 C1 180.000 10.0 3
+ALPHA1-4 sp3_sp3_4 1 C5 1 C4 1 O4 2 C1 60.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA1-4 2 C1 2 O5 1 O4 2 C2 positive
+
+data_link_ALPHA1-6
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA1-6 1 O6 2 C1 SINGLE 1.402 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA1-6 1 C6 1 O6 2 C1 113.644 2.19
+ALPHA1-6 2 C2 2 C1 1 O6 107.610 1.50
+ALPHA1-6 2 O5 2 C1 1 O6 108.458 3.00
+ALPHA1-6 1 O6 2 C1 2 H1 110.090 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA1-6 sp3_sp3_1 2 C2 2 C1 1 O6 1 C6 180.000 10.0 3
+ALPHA1-6 sp3_sp3_2 2 O5 2 C1 1 O6 1 C6 60.000 10.0 3
+ALPHA1-6 sp3_sp3_3 1 C5 1 C6 1 O6 2 C1 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA1-6 2 C1 1 O6 2 O5 2 C2 negative
+
+data_link_ALPHA1-7
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA1-7 1 O7 2 C1 SINGLE 1.405 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA1-7 1 C7 1 O7 2 C1 113.155 1.50
+ALPHA1-7 2 C2 2 C1 1 O7 108.405 3.00
+ALPHA1-7 2 O5 2 C1 1 O7 109.266 3.00
+ALPHA1-7 1 O7 2 C1 2 H1 109.587 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA1-7 sp3_sp3_1 2 C2 2 C1 1 O7 1 C7 180.000 10.0 3
+ALPHA1-7 sp3_sp3_2 2 O5 2 C1 1 O7 1 C7 60.000 10.0 3
+ALPHA1-7 sp3_sp3_3 1 C6 1 C7 1 O7 2 C1 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA1-7 2 C1 2 O5 1 O7 2 C2 positive
+
+data_link_BETA1-2
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA1-2 1 O2 2 C1 SINGLE 1.393 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA1-2 1 C2 1 O2 2 C1 115.777 3.00
+BETA1-2 2 C2 2 C1 1 O2 108.448 3.00
+BETA1-2 2 O5 2 C1 1 O2 110.493 3.00
+BETA1-2 1 O2 2 C1 2 H1 109.294 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA1-2 sp3_sp3_1 2 C2 2 C1 1 O2 1 C2 180.000 10.0 3
+BETA1-2 sp3_sp3_2 2 O5 2 C1 1 O2 1 C2 60.000 10.0 3
+BETA1-2 sp3_sp3_3 1 C1 1 C2 1 O2 2 C1 180.000 10.0 3
+BETA1-2 sp3_sp3_4 1 C3 1 C2 1 O2 2 C1 60.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA1-2 2 C1 1 O2 2 O5 2 C2 positiv
+
+data_link_BETA1-3
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA1-3 1 O3 2 C1 SINGLE 1.393 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA1-3 1 C3 1 O3 2 C1 114.436 2.55
+BETA1-3 2 C2 2 C1 1 O3 108.448 3.00
+BETA1-3 2 O5 2 C1 1 O3 110.493 3.00
+BETA1-3 1 O3 2 C1 2 H1 109.294 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA1-3 sp3_sp3_1 2 C2 2 C1 1 O3 1 C3 180.000 10.0 3
+BETA1-3 sp3_sp3_2 2 O5 2 C1 1 O3 1 C3 60.000 10.0 3
+BETA1-3 sp3_sp3_3 1 C2 1 C3 1 O3 2 C1 180.000 10.0 3
+BETA1-3 sp3_sp3_4 1 C4 1 C3 1 O3 2 C1 60.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA1-3 2 C1 2 O5 1 O3 2 C2 negative
+
+data_link_BETA1-4
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA1-4 1 O4 2 C1 SINGLE 1.393 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA1-4 1 C4 1 O4 2 C1 117.674 3.00
+BETA1-4 2 C2 2 C1 1 O4 108.448 3.00
+BETA1-4 2 O5 2 C1 1 O4 110.493 3.00
+BETA1-4 1 O4 2 C1 2 H1 109.294 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA1-4 sp3_sp3_1 2 C2 2 C1 1 O4 1 C4 180.000 10.0 3
+BETA1-4 sp3_sp3_2 2 O5 2 C1 1 O4 1 C4 60.000 10.0 3
+BETA1-4 sp3_sp3_3 1 C3 1 C4 1 O4 2 C1 180.000 10.0 3
+BETA1-4 sp3_sp3_4 1 C5 1 C4 1 O4 2 C1 60.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA1-4 2 C1 2 O5 1 O4 2 C2 negative
+
+data_link_BETA1-6
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA1-6 1 O6 2 C1 SINGLE 1.402 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA1-6 1 C6 1 O6 2 C1 113.644 2.19
+BETA1-6 2 C2 2 C1 1 O6 107.610 1.50
+BETA1-6 2 O5 2 C1 1 O6 108.458 3.00
+BETA1-6 1 O6 2 C1 2 H1 110.090 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA1-6 sp3_sp3_1 2 C2 2 C1 1 O6 1 C6 180.000 10.0 3
+BETA1-6 sp3_sp3_2 2 O5 2 C1 1 O6 1 C6 60.000 10.0 3
+BETA1-6 sp3_sp3_3 1 C5 1 C6 1 O6 2 C1 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA1-6 2 C1 1 O6 2 O5 2 C2 positive
+
+data_link_BETA1-7
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA1-7 1 O7 2 C1 SINGLE 1.405 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA1-7 1 C7 1 O7 2 C1 113.155 1.50
+BETA1-7 2 C2 2 C1 1 O7 108.405 3.00
+BETA1-7 2 O5 2 C1 1 O7 109.266 3.00
+BETA1-7 1 O7 2 C1 2 H1 109.587 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA1-7 sp3_sp3_1 2 C2 2 C1 1 O7 1 C7 180.000 10.0 3
+BETA1-7 sp3_sp3_2 2 O5 2 C1 1 O7 1 C7 60.000 10.0 3
+BETA1-7 sp3_sp3_3 1 C6 1 C7 1 O7 2 C1 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA1-7 2 C1 2 O5 1 O7 2 C2 negative
+
+data_link_pyr-SER
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pyr-SER 1 C1 2 OG single 1.439 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pyr-SER 1 C1 2 OG 2 CB 108.700 3.000
+pyr-SER 1 O5 1 C1 2 OG 112.300 3.000
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+pyr-SER 1 C1 2 OG 1 O5 1 C2 positiv
+
+data_link_pyr-THR
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pyr-THR 1 C1 2 OG1 single 1.439 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pyr-THR 1 C1 2 OG1 2 CB 108.700 3.000
+pyr-THR 1 O5 1 C1 2 OG1 112.300 3.000
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+pyr-THR 1 C1 2 OG1 1 O5 1 C2 positiv
+
+data_link_pyr-ASN
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pyr-ASN 1 C1 2 ND2 single 1.439 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pyr-ASN 1 C1 2 ND2 2 CG 121.000 3.000
+pyr-ASN 1 C1 2 ND2 2 HD21 119.000 3.000
+pyr-ASN 1 O5 1 C1 2 ND2 112.300 3.000
+pyr-ASN 1 C2 1 C1 2 ND2 112.700 3.000
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pyr-ASN plane1 1 C1 .020
+pyr-ASN plane1 2 ND2 .020
+pyr-ASN plane1 2 CG .020
+pyr-ASN plane1 2 OD1 .020
+pyr-ASN plane1 2 CB .020
+pyr-ASN plane1 2 HD21 .020
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+pyr-ASN 1 C1 2 ND2 1 O5 1 C2 positiv
+
+data_link_ZN-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ZN-CYS 1 ZN 2 SG single 2.340 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ZN-CYS 1 ZN 2 SG 2 CB 109.000 3.000
+
+data_link_ZN-HISND
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ZN-HISND 1 ZN 2 ND1 single 2.057 .064
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ZN-HISND 1 ZN 2 ND1 2 CG 125.350 3.000
+ZN-HISND 1 ZN 2 ND1 2 CE1 125.350 3.000
+
+data_link_ZN-HISNE
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ZN-HISNE 1 ZN 2 NE2 single 2.058 .073
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ZN-HISNE 1 ZN 2 NE2 2 CD2 125.500 3.000
+ZN-HISNE 1 ZN 2 NE2 2 CE1 125.500 3.000
+
+data_link_HEC-CYS1
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+HEC-CYS1 1 CAC 2 SG single 1.765 0.020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+HEC-CYS1 1 CAC 2 SG 2 CB 109.470 3.000
+HEC-CYS1 1 HAC 1 CAC 2 SG 109.500 3.000
+HEC-CYS1 1 CBC 1 CAC 2 SG 109.500 3.000
+HEC-CYS1 1 C3C 1 CAC 2 SG 109.500 3.000
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+HEC-CYS1 chir_04 1 CAC 1 C3C 1 CBC 2 SG both
+
+data_link_HEC-CYS2
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+HEC-CYS2 1 CAB 2 SG single 1.765 0.020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+HEC-CYS2 1 CAB 2 SG 2 CB 109.470 3.000
+HEC-CYS2 1 HAB 1 CAB 2 SG 109.500 3.000
+HEC-CYS2 1 CBB 1 CAB 2 SG 109.500 3.000
+HEC-CYS2 1 C3B 1 CAB 2 SG 109.500 3.000
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+HEC-CYS2 chir_04 1 CAB 1 C3B 1 CBB 2 SG both
+
+data_link_FE-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+FE-CYS 1 FE 2 SG single 2.260 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+FE-CYS 1 FE 2 SG 2 CB 109.470 3.000
+
+data_link_FE-HISND
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+FE-HISND 1 FE 2 ND1 single 2.057 .064
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+FE-HISND 1 FE 2 ND1 2 CG 125.350 3.000
+FE-HISND 1 FE 2 ND1 2 CE1 125.350 3.000
+
+data_link_FE-HISNE
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+FE-HISNE 1 FE 2 NE2 single 2.058 .073
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+FE-HISNE 1 FE 2 NE2 2 CD2 125.500 3.000
+FE-HISNE 1 FE 2 NE2 2 CE1 125.500 3.000
+
+data_link_FES1-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+FES1-CYS 1 FE1 2 SG single 2.280 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+FES1-CYS 1 FE1 2 SG 2 CB 105.8 3.00
+FES1-CYS 1 S1 1 FE1 2 SG 111.0 3.00
+FES1-CYS 1 S2 1 FE1 2 SG 111.0 3.00
+
+data_link_FES2-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+FES2-CYS 1 FE2 2 SG single 2.280 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+FES2-CYS 1 FE2 2 SG 2 CB 105.8 3.00
+FES2-CYS 1 S1 1 FE2 2 SG 111.0 3.00
+FES2-CYS 1 S2 1 FE2 2 SG 111.0 3.00
+
+data_link_SF41-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SF41-CYS 1 FE1 2 SG single 2.260 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SF41-CYS 1 FE1 2 SG 2 CB 113.470 3.000
+
+data_link_SF42-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SF42-CYS 1 FE2 2 SG single 2.260 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SF42-CYS 1 FE2 2 SG 2 CB 113.470 3.000
+
+data_link_SF43-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SF43-CYS 1 FE3 2 SG single 2.260 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SF43-CYS 1 FE3 2 SG 2 CB 113.470 3.000
+
+data_link_SF44-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SF44-CYS 1 FE4 2 SG single 2.260 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SF44-CYS 1 FE4 2 SG 2 CB 113.470 3.000
+
+data_link_SF31-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SF31-CYS 1 FE1 2 SG single 2.260 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SF31-CYS 1 FE1 2 SG 2 CB 113.470 3.000
+
+data_link_SF37-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SF37-CYS 1 FE7 2 SG single 2.260 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SF37-CYS 1 FE7 2 SG 2 CB 113.470 3.000
+
+data_link_SF33-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SF33-CYS 1 FE3 2 SG single 2.260 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SF33-CYS 1 FE3 2 SG 2 CB 113.470 3.000
+
+data_link_SF34-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+SF34-CYS 1 FE4 2 SG single 2.260 .020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+SF34-CYS 1 FE4 2 SG 2 CB 113.470 3.000
+
+data_link_ACYSNN
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ACYSNN 1 CH3 2 N1 SINGLE 1.456 0.0102
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ACYSNN 1 C 1 CH3 2 N1 113.834 1.50
+ACYSNN 2 N1 1 CH3 1 H1 109.044 1.50
+ACYSNN 2 N1 1 CH3 1 H2 109.044 1.50
+ACYSNN 2 C 2 N1 1 CH3 123.734 2.62
+ACYSNN 2 C5 2 N1 1 CH3 123.734 2.62
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ACYSNN sp2_sp3_1 2 C 2 N1 1 CH3 1 C -90.000 10.0 6
+ACYSNN sp2_sp2_1 2 O 2 C 2 N1 1 CH3 0.000 5.0 2
+ACYSNN sp2_sp3_2 1 O 1 C 1 CH3 2 N1 120.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+ACYSNN plan-2 2 C5 0.020
+ACYSNN plan-2 1 CH3 0.020
+ACYSNN plan-2 2 C 0.020
+ACYSNN plan-2 2 N1 0.020
+
+data_link_pept-SNN
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-SNN 1 C 2 N SINGLE 1.338 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-SNN 1 CA 1 C 2 N 117.912 3.00
+pept-SNN 1 O 1 C 2 N 123.381 1.50
+pept-SNN 2 CA 2 N 1 C 121.847 1.50
+pept-SNN 1 C 2 N 2 H33 118.403 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-SNN sp2_sp2_1 1 CA 1 C 2 N 2 CA 180.000 5.0 2
+pept-SNN sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-SNN plan-1 1 CA 0.020
+pept-SNN plan-1 1 C 0.020
+pept-SNN plan-1 2 N 0.020
+pept-SNN plan-1 1 O 0.020
+pept-SNN plan-4 2 CA 0.020
+pept-SNN plan-4 1 C 0.020
+pept-SNN plan-4 2 H33 0.020
+pept-SNN plan-4 2 N 0.020
+
+data_link_TPN-TPN
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+TPN-TPN 1 C 2 N single 1.330 0.020
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+TPN-TPN 1 C 2 N 2 "C2'" 121.500 3.000
+TPN-TPN 1 C 2 N 2 H 120.000 3.000
+TPN-TPN 1 O 1 C 2 N 123.000 3.000
+TPN-TPN 1 "C5'" 1 C 2 N 116.500 3.000
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+TPN-TPN plan-7 1 "C5'" 0.020
+TPN-TPN plan-7 1 C 0.020
+TPN-TPN plan-7 1 O 0.020
+TPN-TPN plan-7 2 N 0.020
+TPN-TPN plan-7 2 H 0.020
+TPN-TPN plan-9 1 C 0.020
+TPN-TPN plan-9 2 "C2'" 0.020
+TPN-TPN plan-9 2 N 0.020
+TPN-TPN plan-9 2 H 0.020
+
+data_link_pept-ORN
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-ORN 1 C 2 NE SINGLE 1.329 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-ORN 1 CA 1 C 2 NE 116.218 3.00
+pept-ORN 1 O 1 C 2 NE 123.265 1.50
+pept-ORN 2 CD 2 NE 1 C 123.642 3.00
+pept-ORN 1 C 2 NE 2 HE1 118.237 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-ORN sp2_sp2_1 1 CA 1 C 2 NE 2 CD 180.000 5 2
+pept-ORN sp2_sp3_1 1 C 2 NE 2 CD 2 CG 120.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-ORN plan-1 1 CA 0.020
+pept-ORN plan-1 1 C 0.020
+pept-ORN plan-1 2 NE 0.020
+pept-ORN plan-1 1 O 0.020
+pept-ORN plan-2 2 CD 0.020
+pept-ORN plan-2 1 C 0.020
+pept-ORN plan-2 2 HE1 0.020
+pept-ORN plan-2 2 NE 0.020
+
+data_link_symmetry
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+symmetry 0 . 0 . . .000 .020
+
+data_link_02J-pept
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+02J-pept 1 C 2 N SINGLE 1.348 0.0110
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+02J-pept 1 CA 1 C 2 N 115.312 1.72
+02J-pept 1 O 1 C 2 N 122.722 2.98
+02J-pept 2 CA 2 N 1 C 120.746 2.17
+02J-pept 1 C 2 N 2 H 119.041 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+02J-pept sp2_sp2_1 1 O 1 C 2 N 2 CA 0.000 5.0 2
+02J-pept sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+02J-pept plan-2 1 CA 0.020
+02J-pept plan-2 1 C 0.020
+02J-pept plan-2 2 N 0.020
+02J-pept plan-2 1 O 0.020
+02J-pept plan-3 2 CA 0.020
+02J-pept plan-3 1 C 0.020
+02J-pept plan-3 2 H 0.020
+02J-pept plan-3 2 N 0.020
+
+data_link_ALPHA2-4
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA2-4 1 O4 2 C2 SINGLE 1.424 0.0200
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA2-4 1 C4 1 O4 2 C2 116.671 3.00
+ALPHA2-4 2 C1 2 C2 1 O4 108.549 3.00
+ALPHA2-4 2 C3 2 C2 1 O4 109.292 3.00
+ALPHA2-4 2 O6 2 C2 1 O4 110.235 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA2-4 sp3_sp3_1 2 C1 2 C2 1 O4 1 C4 180.000 10.0 3
+ALPHA2-4 sp2_sp3_1 2 O1A 2 C1 2 C2 1 O4 -120.000 10.0 6
+ALPHA2-4 sp3_sp3_2 1 C3 1 C4 1 O4 2 C2 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA2-4 2 C2 2 O6 1 O4 2 C1 negative
+
+data_link_ALPHA1-5
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA1-5 1 O5 2 C1 SINGLE 1.393 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA1-5 1 C5 1 O5 2 C1 117.674 3.00
+ALPHA1-5 2 C2 2 C1 1 O5 108.448 3.00
+ALPHA1-5 2 O5 2 C1 1 O5 110.493 3.00
+ALPHA1-5 1 O5 2 C1 2 H1 109.294 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA1-5 sp3_sp3_1 2 C2 2 C1 1 O5 1 C5 180.000 10.0 3
+ALPHA1-5 sp3_sp3_2 2 O5 2 C1 1 O5 1 C5 60.000 10.0 3
+ALPHA1-5 sp3_sp3_3 1 C4 1 C5 1 O5 2 C1 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA1-5 2 C1 2 O5 1 O5 2 C2 positive
+
+data_link_BETA2-4
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA2-4 1 O4 2 C2 SINGLE 1.424 0.0200
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA2-4 1 C4 1 O4 2 C2 116.671 3.00
+BETA2-4 2 C1 2 C2 1 O4 108.549 3.00
+BETA2-4 2 C3 2 C2 1 O4 109.292 3.00
+BETA2-4 2 O6 2 C2 1 O4 110.235 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA2-4 sp3_sp3_1 2 C1 2 C2 1 O4 1 C4 180.000 10.0 3
+BETA2-4 sp2_sp3_1 2 O1A 2 C1 2 C2 1 O4 -120.000 10.0 6
+BETA2-4 sp3_sp3_2 1 C3 1 C4 1 O4 2 C2 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA2-4 2 C2 2 O6 1 O4 2 C1 positive
+
+data_link_BETA1-5
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA1-5 1 O5 2 C1 SINGLE 1.393 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA1-5 1 C5 1 O5 2 C1 117.674 3.00
+BETA1-5 2 C2 2 C1 1 O5 108.448 3.00
+BETA1-5 2 O5 2 C1 1 O5 110.493 3.00
+BETA1-5 1 O5 2 C1 2 H1 109.294 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA1-5 sp3_sp3_1 2 C2 2 C1 1 O5 1 C5 180.000 10.0 3
+BETA1-5 sp3_sp3_2 2 O5 2 C1 1 O5 1 C5 60.000 10.0 3
+BETA1-5 sp3_sp3_3 1 C4 1 C5 1 O5 2 C1 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA1-5 2 C1 2 O5 1 O5 2 C2 negative
+
+data_link_ALPHA2-6
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA2-6 1 O6 2 C2 SINGLE 1.411 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA2-6 1 C6 1 O6 2 C2 114.624 2.88
+ALPHA2-6 2 C1 2 C2 1 O6 108.549 3.00
+ALPHA2-6 2 C3 2 C2 1 O6 104.665 1.50
+ALPHA2-6 2 O6 2 C2 1 O6 110.760 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA2-6 sp3_sp3_1 2 C1 2 C2 1 O6 1 C6 180.000 10.0 3
+ALPHA2-6 sp3_sp3_6 1 C5 1 C6 1 O6 2 C2 180.000 10.0 3
+ALPHA2-6 sp2_sp3_2 2 O1B 2 C1 2 C2 1 O6 60.000 10.0 6
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA2-6 2 C2 2 O6 1 O6 2 C1 negative
+
+data_link_ALPHA2-8
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+ALPHA2-8 1 O8 2 C2 SINGLE 1.411 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+ALPHA2-8 1 C8 1 O8 2 C2 114.624 2.88
+ALPHA2-8 2 C1 2 C2 1 O8 108.549 3.00
+ALPHA2-8 2 C3 2 C2 1 O8 104.665 1.50
+ALPHA2-8 2 O6 2 C2 1 O8 110.760 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+ALPHA2-8 sp3_sp3_1 2 C1 2 C2 1 O8 1 C8 180.000 10.0 3
+ALPHA2-8 sp2_sp3_1 2 O1A 2 C1 2 C2 1 O8 -120.000 10.0 6
+ALPHA2-8 sp3_sp3_2 1 C7 1 C8 1 O8 2 C2 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+ALPHA2-8 2 C2 2 O6 1 O8 2 C1 negative
+
+data_link_BETA2-8
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA2-8 1 O8 2 C2 SINGLE 1.411 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA2-8 1 C8 1 O8 2 C2 114.624 2.88
+BETA2-8 2 C1 2 C2 1 O8 108.549 3.00
+BETA2-8 2 C3 2 C2 1 O8 104.665 1.50
+BETA2-8 2 O6 2 C2 1 O8 110.760 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA2-8 sp3_sp3_1 2 C1 2 C2 1 O8 1 C8 180.000 10.0 3
+BETA2-8 sp2_sp3_1 2 O1A 2 C1 2 C2 1 O8 -120.000 10.0 6
+BETA2-8 sp3_sp3_2 1 C7 1 C8 1 O8 2 C2 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA2-8 2 C2 2 O6 1 O8 2 C1 positive
+
+data_link_BETA2-6
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+BETA2-6 1 O6 2 C2 SINGLE 1.411 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+BETA2-6 1 C6 1 O6 2 C2 114.624 2.88
+BETA2-6 2 C1 2 C2 1 O6 108.549 3.00
+BETA2-6 2 C3 2 C2 1 O6 104.665 1.50
+BETA2-6 2 O6 2 C2 1 O6 110.760 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+BETA2-6 sp3_sp3_1 2 C1 2 C2 1 O6 1 C6 180.000 10.0 3
+BETA2-6 sp3_sp3_6 1 C5 1 C6 1 O6 2 C2 180.000 10.0 3
+BETA2-6 sp2_sp3_2 2 O1B 2 C1 2 C2 1 O6 60.000 10.0 6
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+BETA2-6 2 C2 2 O6 1 O6 2 C1 positive
+
+data_link_CYS-BME
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CYS-BME 1 SG 2 S2 SINGLE 2.023 0.0152
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CYS-BME 1 CB 1 SG 2 S2 103.493 1.52
+CYS-BME 2 C2 2 S2 1 SG 103.571 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CYS-BME sp3_sp3_1 2 C2 2 S2 1 SG 1 CB 180.000 10.00 3
+
+data_link_CR8-pept
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CR8-pept 1 C3 2 N SINGLE 1.339 0.0146
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CR8-pept 1 CA3 1 C3 2 N 116.032 3.00
+CR8-pept 1 O3 1 C3 2 N 123.316 1.64
+CR8-pept 2 CA 2 N 1 C3 121.976 2.97
+CR8-pept 1 C3 2 N 2 H 119.006 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CR8-pept sp2_sp2_1 1 CA3 1 C3 2 N 2 CA 180.000 5.0 2
+CR8-pept sp2_sp3_1 1 C3 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+CR8-pept plan-10 1 C3 0.020
+CR8-pept plan-10 1 CA3 0.020
+CR8-pept plan-10 2 N 0.020
+CR8-pept plan-10 1 O3 0.020
+CR8-pept plan-11 1 C3 0.020
+CR8-pept plan-11 2 CA 0.020
+CR8-pept plan-11 2 H 0.020
+CR8-pept plan-11 2 N 0.020
+
+data_link_CRO-pept
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CRO-pept 1 C3 2 N SINGLE 1.334 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CRO-pept 1 CA3 1 C3 2 N 114.639 1.99
+CRO-pept 1 O3 1 C3 2 N 123.577 1.50
+CRO-pept 2 CA 2 N 1 C3 121.878 1.76
+CRO-pept 1 C3 2 N 2 H 118.768 1.94
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CRO-pept sp2_sp2_1 1 CA3 1 C3 2 N 2 CA 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+CRO-pept plan-5 1 CA3 0.020
+CRO-pept plan-5 1 C3 0.020
+CRO-pept plan-5 2 N 0.020
+CRO-pept plan-5 1 O3 0.020
+CRO-pept plan-8 1 C3 0.020
+CRO-pept plan-8 2 CA 0.020
+CRO-pept plan-8 2 H 0.020
+CRO-pept plan-8 2 N 0.020
+
+data_link_CYS-CYC
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CYS-CYC 1 SG 2 CAC SINGLE 1.834 0.0113
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CYS-CYC 1 CB 1 SG 2 CAC 101.799 3.00
+CYS-CYC 2 C3C 2 CAC 1 SG 112.870 3.00
+CYS-CYC 2 CBC 2 CAC 1 SG 109.480 3.00
+CYS-CYC 1 SG 2 CAC 2 HAC1 108.186 1.88
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CYS-CYC sp3_sp3_1 2 CBC 2 CAC 1 SG 1 CB 60.000 10.0 3
+CYS-CYC sp3_sp3_2 1 CA 1 CB 1 SG 2 CAC 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+CYS-CYC 2 CAC 1 SG 2 C3C 2 CBC both
+
+data_link_CYS-FAD
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CYS-FAD 1 SG 2 C8M SINGLE 1.820 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CYS-FAD 1 CB 1 SG 2 C8M 101.044 3.00
+CYS-FAD 2 C8 2 C8M 1 SG 113.672 3.00
+CYS-FAD 1 SG 2 C8M 2 HM81 108.732 1.50
+CYS-FAD 1 SG 2 C8M 2 HM82 108.732 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CYS-FAD sp3_sp3_1 2 C8 2 C8M 1 SG 1 CB 180.000 10.0 3
+CYS-FAD sp2_sp3_1 2 C7 2 C8 2 C8M 1 SG -90.000 10.0 6
+CYS-FAD sp3_sp3_2 1 CA 1 CB 1 SG 2 C8M 180.000 10.0 3
+
+data_link_CYS-PEB
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CYS-PEB 1 SG 2 CAA SINGLE 1.834 0.0113
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CYS-PEB 1 CB 1 SG 2 CAA 101.799 3.00
+CYS-PEB 2 C3A 2 CAA 1 SG 112.870 3.00
+CYS-PEB 2 CBA 2 CAA 1 SG 109.480 3.00
+CYS-PEB 1 SG 2 CAA 2 HAA1 108.186 1.88
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CYS-PEB sp3_sp3_1 2 CBA 2 CAA 1 SG 1 CB 60.000 10.0 3
+CYS-PEB sp3_sp3_2 1 CA 1 CB 1 SG 2 CAA 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+CYS-PEB 2 CAA 1 SG 2 C3A 2 CBA both
+
+data_link_Ddisul
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+Ddisul 1 SG 2 SG SINGLE 2.023 0.0152
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+Ddisul 1 CB 1 SG 2 SG 103.493 1.52
+Ddisul 2 CB 2 SG 1 SG 103.493 1.52
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+Ddisul sp3_sp3_1 2 CB 2 SG 1 SG 1 CB 180.000 10.00 3
+
+data_link_HIS-FAD1
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+HIS-FAD1 1 ND1 2 C8M SINGLE 1.467 0.0125
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+HIS-FAD1 1 CG 1 ND1 2 C8M 125.176 2.51
+HIS-FAD1 1 CE1 1 ND1 2 C8M 126.099 1.66
+HIS-FAD1 2 C8 2 C8M 1 ND1 112.614 2.48
+HIS-FAD1 1 ND1 2 C8M 2 HM81 108.931 1.50
+HIS-FAD1 1 ND1 2 C8M 2 HM82 108.931 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+HIS-FAD1 sp2_sp3_1 1 CG 1 ND1 2 C8M 2 C8 -90.000 10.0 6
+HIS-FAD1 sp2_sp3_2 2 C7 2 C8 2 C8M 1 ND1 -90.000 10.0 6
+HIS-FAD1 const_82_1 1 CB 1 CG 1 ND1 2 C8M 0.000 0.0 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+HIS-FAD1 plan-6 1 CB 0.020
+HIS-FAD1 plan-6 2 C8M 0.020
+HIS-FAD1 plan-6 1 CG 0.020
+HIS-FAD1 plan-6 1 CD2 0.020
+HIS-FAD1 plan-6 1 CE1 0.020
+HIS-FAD1 plan-6 1 HD2 0.020
+HIS-FAD1 plan-6 1 HE1 0.020
+HIS-FAD1 plan-6 1 HE2 0.020
+HIS-FAD1 plan-6 1 NE2 0.020
+HIS-FAD1 plan-6 1 ND1 0.020
+
+data_link_HIS-FAD2
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+HIS-FAD2 1 NE2 2 C8M SINGLE 1.477 0.0113
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+HIS-FAD2 1 CD2 1 NE2 2 C8M 125.649 2.86
+HIS-FAD2 1 CE1 1 NE2 2 C8M 126.201 1.50
+HIS-FAD2 2 C8 2 C8M 1 NE2 112.614 2.48
+HIS-FAD2 1 NE2 2 C8M 2 HM81 109.095 1.50
+HIS-FAD2 1 NE2 2 C8M 2 HM82 109.095 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+HIS-FAD2 sp2_sp3_1 1 CD2 1 NE2 2 C8M 2 C8 -90.000 10.0 6
+HIS-FAD2 sp2_sp3_2 2 C7 2 C8 2 C8M 1 NE2 -90.000 10.0 6
+HIS-FAD2 const_92_1 1 CG 1 CD2 1 NE2 2 C8M 180.000 0.0 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+HIS-FAD2 plan-6 1 CB 0.020
+HIS-FAD2 plan-6 2 C8M 0.020
+HIS-FAD2 plan-6 1 CG 0.020
+HIS-FAD2 plan-6 1 CD2 0.020
+HIS-FAD2 plan-6 1 CE1 0.020
+HIS-FAD2 plan-6 1 HD1 0.020
+HIS-FAD2 plan-6 1 HD2 0.020
+HIS-FAD2 plan-6 1 HE1 0.020
+HIS-FAD2 plan-6 1 NE2 0.020
+HIS-FAD2 plan-6 1 ND1 0.020
+
+data_link_GTP-p
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+GTP-p 1 "O3'" 2 P SINGLE 1.607 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+GTP-p 1 "C3'" 1 "O3'" 2 P 121.082 1.50
+GTP-p 2 OP1 2 P 1 "O3'" 109.493 3.00
+GTP-p 2 OP2 2 P 1 "O3'" 109.493 3.00
+GTP-p 2 "O5'" 2 P 1 "O3'" 100.661 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+GTP-p sp3_sp3_1 1 "C3'" 1 "O3'" 2 P 2 OP1 60.000 10.0 3
+GTP-p sp3_sp3_2 1 "C4'" 1 "C3'" 1 "O3'" 2 P 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+GTP-p 2 P 2 "O5'" 1 "O3'" 2 OP2 both
+
+data_link_GYC-pept
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+GYC-pept 1 C3 2 N SINGLE 1.334 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+GYC-pept 1 CA3 1 C3 2 N 114.639 1.99
+GYC-pept 1 O3 1 C3 2 N 123.577 1.50
+GYC-pept 2 CA 2 N 1 C3 121.878 1.76
+GYC-pept 1 C3 2 N 2 H 118.768 1.94
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+GYC-pept sp2_sp2_1 1 CA3 1 C3 2 N 2 CA 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+GYC-pept plan-7 1 CA3 0.020
+GYC-pept plan-7 1 C3 0.020
+GYC-pept plan-7 2 N 0.020
+GYC-pept plan-7 1 O3 0.020
+GYC-pept plan-9 1 C3 0.020
+GYC-pept plan-9 2 CA 0.020
+GYC-pept plan-9 2 H 0.020
+GYC-pept plan-9 2 N 0.020
+
+data_link_CYS-HEMB
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CYS-HEMB 1 SG 2 CAB SINGLE 1.825 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CYS-HEMB 1 CB 1 SG 2 CAB 101.840 1.86
+CYS-HEMB 2 C3B 2 CAB 1 SG 112.260 2.46
+CYS-HEMB 2 CBB 2 CAB 1 SG 112.239 3.00
+CYS-HEMB 1 SG 2 CAB 2 HAB 107.632 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CYS-HEMB sp3_sp3_1 2 CBB 2 CAB 1 SG 1 CB 180.000 10.00 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+CYS-HEMB 2 CAB 1 SG 2 C3B 2 CBB both
+
+data_link_CYS-HEMC
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+CYS-HEMC 1 SG 2 CAC SINGLE 1.825 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+CYS-HEMC 1 CB 1 SG 2 CAC 101.840 1.86
+CYS-HEMC 2 C3C 2 CAC 1 SG 112.260 2.46
+CYS-HEMC 2 CBC 2 CAC 1 SG 112.239 3.00
+CYS-HEMC 1 SG 2 CAC 2 HAC 107.632 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+CYS-HEMC sp3_sp3_1 2 CBC 2 CAC 1 SG 1 CB 180.000 10.00 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+CYS-HEMC 2 CAC 1 SG 2 C3C 2 CBC both
+
+data_link_HIS_TYR1
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+HIS_TYR1 1 ND1 2 CB SINGLE 1.479 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+HIS_TYR1 1 CG 1 ND1 2 CB 126.908 3.00
+HIS_TYR1 1 CE1 1 ND1 2 CB 124.367 2.36
+HIS_TYR1 2 CA 2 CB 1 ND1 111.116 3.00
+HIS_TYR1 2 CG 2 CB 1 ND1 110.829 1.95
+HIS_TYR1 1 ND1 2 CB 2 HB2 106.371 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+HIS_TYR1 sp2_sp3_1 1 CG 1 ND1 2 CB 2 CA 150.000 10.0 6
+HIS_TYR1 const_24_1 1 CB 1 CG 1 ND1 2 CB 0.000 0.0 2
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+HIS_TYR1 2 CB 1 ND1 2 CA 2 CG both
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+HIS_TYR1 plan-2 2 CB 0.020
+HIS_TYR1 plan-2 1 CB 0.020
+HIS_TYR1 plan-2 1 CG 0.020
+HIS_TYR1 plan-2 1 CD2 0.020
+HIS_TYR1 plan-2 1 CE1 0.020
+HIS_TYR1 plan-2 1 HD2 0.020
+HIS_TYR1 plan-2 1 HE1 0.020
+HIS_TYR1 plan-2 1 HE2 0.020
+HIS_TYR1 plan-2 1 NE2 0.020
+HIS_TYR1 plan-2 1 ND1 0.020
+
+data_link_HIS_TYR2
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+HIS_TYR2 1 NE2 2 CE2 SINGLE 1.447 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+HIS_TYR2 1 CD2 1 NE2 2 CE2 126.913 1.60
+HIS_TYR2 1 CE1 1 NE2 2 CE2 124.723 2.73
+HIS_TYR2 2 CD2 2 CE2 1 NE2 119.776 1.50
+HIS_TYR2 2 CZ 2 CE2 1 NE2 120.443 1.51
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+HIS_TYR2 sp2_sp2_1 2 CD2 2 CE2 1 NE2 1 CD2 180.000 20 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+HIS_TYR2 plan-1 2 CB 0.020
+HIS_TYR2 plan-1 2 CG 0.020
+HIS_TYR2 plan-1 2 CD1 0.020
+HIS_TYR2 plan-1 2 CD2 0.020
+HIS_TYR2 plan-1 2 CE1 0.020
+HIS_TYR2 plan-1 2 CE2 0.020
+HIS_TYR2 plan-1 2 CZ 0.020
+HIS_TYR2 plan-1 2 HD1 0.020
+HIS_TYR2 plan-1 2 HD2 0.020
+HIS_TYR2 plan-1 2 HE1 0.020
+HIS_TYR2 plan-1 1 NE2 0.020
+HIS_TYR2 plan-1 2 OH 0.020
+HIS_TYR2 plan-2 2 CE2 0.020
+HIS_TYR2 plan-2 1 CB 0.020
+HIS_TYR2 plan-2 1 CG 0.020
+HIS_TYR2 plan-2 1 CD2 0.020
+HIS_TYR2 plan-2 1 CE1 0.020
+HIS_TYR2 plan-2 1 HD1 0.020
+HIS_TYR2 plan-2 1 HD2 0.020
+HIS_TYR2 plan-2 1 HE1 0.020
+HIS_TYR2 plan-2 1 NE2 0.020
+HIS_TYR2 plan-2 1 ND1 0.020
+
+data_link_IAS-pept
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+IAS-pept 1 CG 2 N SINGLE 1.334 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+IAS-pept 1 CB 1 CG 2 N 116.493 1.50
+IAS-pept 1 OD1 1 CG 2 N 122.216 1.50
+IAS-pept 2 CA 2 N 1 CG 121.923 1.76
+IAS-pept 1 CG 2 N 2 H 118.677 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+IAS-pept sp2_sp2_1 1 CB 1 CG 2 N 2 CA 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+IAS-pept plan-4 2 CA 0.020
+IAS-pept plan-4 1 CG 0.020
+IAS-pept plan-4 2 H 0.020
+IAS-pept plan-4 2 N 0.020
+IAS-pept plan-2 1 CB 0.020
+IAS-pept plan-2 1 CG 0.020
+IAS-pept plan-2 2 N 0.020
+IAS-pept plan-2 1 OD1 0.020
+
+data_link_pept-IAS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-IAS 1 C 2 N SINGLE 1.337 0.011
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-IAS 1 CA 1 C 2 N 115.917 1.50
+pept-IAS 1 O 1 C 2 N 123.469 1.50
+pept-IAS 1 C 2 N 2 CA 122.095 1.76
+pept-IAS 1 C 2 N 2 H 119.176 1.83
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-IAS psi 1 N 1 CA 1 C 2 N 160.00 30.0 2
+pept-IAS omega 1 CA 1 C 2 N 2 CA 180.00 5.0 2
+pept-IAS phi 1 C 2 N 2 CA 2 C 60.00 20.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-IAS plan-1 1 CA 0.020
+pept-IAS plan-1 1 C 0.020
+pept-IAS plan-1 2 N 0.020
+pept-IAS plan-1 1 O 0.020
+pept-IAS plan-2 2 CA 0.020
+pept-IAS plan-2 1 C 0.020
+pept-IAS plan-2 2 H 0.020
+pept-IAS plan-2 2 N 0.020
+
+data_link_LYS-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+LYS-CYS 1 NZ 2 SG SINGLE 1.682 0.0176
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+LYS-CYS 1 CE 1 NZ 2 SG 116.537 1.50
+LYS-CYS 2 SG 1 NZ 1 HZ1 110.707 3.00
+LYS-CYS 2 CB 2 SG 1 NZ 109.471 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+LYS-CYS sp3_sp3_1 1 CE 1 NZ 2 SG 2 CB 60.000 10.00 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+LYS-CYS 1 NZ 2 SG 1 CE 1 HZ1 both
+
+data_link_LYS-RET
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+LYS-RET 1 NZ 2 C15 DOUBLE 1.267 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+LYS-RET 1 CE 1 NZ 2 C15 117.696 1.50
+LYS-RET 2 C14 2 C15 1 NZ 119.622 3.00
+LYS-RET 1 NZ 2 C15 2 H15 120.503 1.83
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+LYS-RET sp2_sp2_1 2 C14 2 C15 1 NZ 1 CE 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+LYS-RET plan-12 2 C14 0.020
+LYS-RET plan-12 2 C15 0.020
+LYS-RET plan-12 2 H15 0.020
+LYS-RET plan-12 1 NZ 0.020
+
+data_link_LYS-ASN
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+LYS-ASN 1 NZ 2 CG SINGLE 1.337 0.0118
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+LYS-ASN 1 CE 1 NZ 2 CG 124.480 2.27
+LYS-ASN 2 CG 1 NZ 1 HZ1 117.279 2.10
+LYS-ASN 2 CB 2 CG 1 NZ 116.603 1.50
+LYS-ASN 2 OD1 2 CG 1 NZ 121.996 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+LYS-ASN sp2_sp2_1 2 CB 2 CG 1 NZ 1 CE 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+LYS-ASN plan-4 2 CB 0.020
+LYS-ASN plan-4 2 CG 0.020
+LYS-ASN plan-4 1 NZ 0.020
+LYS-ASN plan-4 2 OD1 0.020
+LYS-ASN plan-1 1 CE 0.020
+LYS-ASN plan-1 2 CG 0.020
+LYS-ASN plan-1 1 HZ1 0.020
+LYS-ASN plan-1 1 NZ 0.020
+
+data_link_MDO-pept
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+MDO-pept 1 C3 2 N SINGLE 1.334 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+MDO-pept 1 CA3 1 C3 2 N 114.639 1.99
+MDO-pept 1 O3 1 C3 2 N 123.577 1.50
+MDO-pept 2 CA 2 N 1 C3 121.878 1.76
+MDO-pept 1 C3 2 N 2 H 118.768 1.94
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+MDO-pept sp2_sp2_1 1 CA3 1 C3 2 N 2 CA 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+MDO-pept plan-6 1 CA3 0.020
+MDO-pept plan-6 1 C3 0.020
+MDO-pept plan-6 2 N 0.020
+MDO-pept plan-6 1 O3 0.020
+MDO-pept plan-8 1 C3 0.020
+MDO-pept plan-8 2 CA 0.020
+MDO-pept plan-8 2 H 0.020
+MDO-pept plan-8 2 N 0.020
+
+data_link_MET-TYR
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+MET-TYR 1 SD 2 CE1 SINGLE 1.780 0.0200
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+MET-TYR 1 CG 1 SD 2 CE1 103.903 1.50
+MET-TYR 1 CE 1 SD 2 CE1 103.843 3.00
+MET-TYR 2 CD1 2 CE1 1 SD 120.241 3.00
+MET-TYR 2 CZ 2 CE1 1 SD 120.124 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+MET-TYR sp2_sp3_1 2 CD1 2 CE1 1 SD 1 CG 150.000 10.0 6
+MET-TYR sp2_sp2_1 2 CG 2 CD1 2 CE1 1 SD 180.000 0.0 2
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+MET-TYR 1 SD 2 CE1 1 CG 1 CE both
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+MET-TYR plan-1 2 CB 0.020
+MET-TYR plan-1 2 CG 0.020
+MET-TYR plan-1 2 CD1 0.020
+MET-TYR plan-1 2 CD2 0.020
+MET-TYR plan-1 2 CE1 0.020
+MET-TYR plan-1 2 CE2 0.020
+MET-TYR plan-1 2 CZ 0.020
+MET-TYR plan-1 2 HD1 0.020
+MET-TYR plan-1 2 HD2 0.020
+MET-TYR plan-1 2 HE2 0.020
+MET-TYR plan-1 2 OH 0.020
+MET-TYR plan-1 1 SD 0.020
+
+data_link_NRQ-pept
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+NRQ-pept 1 C3 2 N SINGLE 1.330 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+NRQ-pept 1 O3 1 C3 2 N 123.577 1.50
+NRQ-pept 1 CA3 1 C3 2 N 114.639 1.99
+NRQ-pept 2 CA 2 N 1 C3 121.722 1.54
+NRQ-pept 1 C3 2 N 2 H 118.975 1.94
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+NRQ-pept sp2_sp2_1 1 O3 1 C3 2 N 2 CA 0.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+NRQ-pept plan-7 1 CA3 0.020
+NRQ-pept plan-7 1 C3 0.020
+NRQ-pept plan-7 2 N 0.020
+NRQ-pept plan-7 1 O3 0.020
+NRQ-pept plan-9 1 C3 0.020
+NRQ-pept plan-9 2 CA 0.020
+NRQ-pept plan-9 2 H 0.020
+NRQ-pept plan-9 2 N 0.020
+
+data_link_PJE-010
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+PJE-010 1 C 2 O SINGLE 1.345 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+PJE-010 1 O 1 C 2 O 122.869 1.79
+PJE-010 1 C21 1 C 2 O 111.652 2.32
+PJE-010 2 C 2 O 1 C 116.306 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+PJE-010 sp2_sp2_1 1 O 1 C 2 O 2 C 180.000 5.0 2
+PJE-010 sp3_sp3_1 2 C6 2 C 2 O 1 C 180.000 10.0 3
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+PJE-010 plan-4 1 C21 0.020
+PJE-010 plan-4 1 C 0.020
+PJE-010 plan-4 1 O 0.020
+PJE-010 plan-4 2 O 0.020
+
+data_link_PJE-CYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+PJE-CYS 1 C20 2 SG SINGLE 1.834 0.0113
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+PJE-CYS 1 C21 1 C20 2 SG 112.610 3.00
+PJE-CYS 1 CA 1 C20 2 SG 112.610 3.00
+PJE-CYS 2 SG 1 C20 1 H15 108.023 2.28
+PJE-CYS 2 CB 2 SG 1 C20 101.799 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+PJE-CYS sp3_sp3_1 1 C21 1 C20 2 SG 2 CB 180.000 10.0 3
+PJE-CYS sp3_sp3_2 2 CA 2 CB 2 SG 1 C20 180.000 10.0 3
+
+loop_
+_chem_link_chir.link_id
+_chem_link_chir.atom_centre_comp_id
+_chem_link_chir.atom_id_centre
+_chem_link_chir.atom_1_comp_id
+_chem_link_chir.atom_id_1
+_chem_link_chir.atom_2_comp_id
+_chem_link_chir.atom_id_2
+_chem_link_chir.atom_3_comp_id
+_chem_link_chir.atom_id_3
+_chem_link_chir.volume_sign
+PJE-CYS 1 C20 2 SG 1 CA 1 C21 both
+
+data_link_PJE-LEU
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+PJE-LEU 1 N 2 C SINGLE 1.337 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+PJE-LEU 1 CA 1 N 2 C 121.950 1.76
+PJE-LEU 2 C 1 N 1 H 119.031 1.83
+PJE-LEU 2 CA 2 C 1 N 115.315 1.50
+PJE-LEU 2 O 2 C 1 N 123.644 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+PJE-LEU sp2_sp2_1 2 CA 2 C 1 N 1 CA 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+PJE-LEU plan-6 1 CA 0.020
+PJE-LEU plan-6 2 C 0.020
+PJE-LEU plan-6 1 H 0.020
+PJE-LEU plan-6 1 N 0.020
+PJE-LEU plan-7 2 CA 0.020
+PJE-LEU plan-7 2 C 0.020
+PJE-LEU plan-7 1 N 0.020
+PJE-LEU plan-7 2 O 0.020
+
+data_link_LYS-PLP
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+LYS-PLP 1 NZ 2 C4A DOUBLE 1.270 0.0174
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+LYS-PLP 1 CE 1 NZ 2 C4A 118.382 1.50
+LYS-PLP 2 C4 2 C4A 1 NZ 122.438 1.52
+LYS-PLP 1 NZ 2 C4A 2 H4A 118.729 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+LYS-PLP sp2_sp2_1 2 C4 2 C4A 1 NZ 1 CE 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+LYS-PLP plan-3 2 C4 0.020
+LYS-PLP plan-3 2 C4A 0.020
+LYS-PLP plan-3 2 H4A 0.020
+LYS-PLP plan-3 1 NZ 0.020
+
+data_link_TRP-TYR
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+TRP-TYR 1 CH2 2 CE2 SINGLE 1.492 0.0125
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+TRP-TYR 1 CZ2 1 CH2 2 CE2 120.507 2.02
+TRP-TYR 1 CZ3 1 CH2 2 CE2 120.338 2.79
+TRP-TYR 2 CD2 2 CE2 1 CH2 120.621 2.79
+TRP-TYR 2 CZ 2 CE2 1 CH2 121.366 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+TRP-TYR sp2_sp2_1 1 CZ2 1 CH2 2 CE2 2 CD2 180.000 5.0 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+TRP-TYR plan-1 1 CE2 0.020
+TRP-TYR plan-1 1 CE3 0.020
+TRP-TYR plan-1 1 CZ2 0.020
+TRP-TYR plan-1 1 CZ3 0.020
+TRP-TYR plan-1 1 CH2 0.020
+TRP-TYR plan-1 2 CE2 0.020
+TRP-TYR plan-1 1 CG 0.020
+TRP-TYR plan-1 1 CD2 0.020
+TRP-TYR plan-1 1 HE3 0.020
+TRP-TYR plan-1 1 HZ2 0.020
+TRP-TYR plan-1 1 HZ3 0.020
+TRP-TYR plan-1 1 NE1 0.020
+TRP-TYR plan-2 1 CH2 0.020
+TRP-TYR plan-2 2 CB 0.020
+TRP-TYR plan-2 2 CG 0.020
+TRP-TYR plan-2 2 CD1 0.020
+TRP-TYR plan-2 2 CD2 0.020
+TRP-TYR plan-2 2 CE1 0.020
+TRP-TYR plan-2 2 CE2 0.020
+TRP-TYR plan-2 2 CZ 0.020
+TRP-TYR plan-2 2 HD1 0.020
+TRP-TYR plan-2 2 HD2 0.020
+TRP-TYR plan-2 2 HE1 0.020
+TRP-TYR plan-2 2 OH 0.020
+
+data_link_pep-NH2
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pep-NH2 1 C 2 N SINGLE 1.324 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pep-NH2 1 CA 1 C 2 N 114.873 1.50
+pep-NH2 1 O 1 C 2 N 123.611 1.50
+pep-NH2 1 C 2 N 2 HN1 119.954 1.50
+pep-NH2 1 C 2 N 2 HN 119.954 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pep-NH2 sp2_sp2_1 1 CA 1 C 2 N 2 HN1 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pep-NH2 plan-1 1 CA 0.020
+pep-NH2 plan-1 1 C 0.020
+pep-NH2 plan-1 2 N 0.020
+pep-NH2 plan-1 1 O 0.020
+pep-NH2 plan-2 1 C 0.020
+pep-NH2 plan-2 2 HN 0.020
+pep-NH2 plan-2 2 HN1 0.020
+pep-NH2 plan-2 2 N 0.020
+
+data_link_pept-CR8
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-CR8 1 C 2 N1 SINGLE 1.343 0.0102
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-CR8 1 CA 1 C 2 N1 116.066 1.50
+pept-CR8 1 O 1 C 2 N1 123.282 1.63
+pept-CR8 2 CA1 2 N1 1 C 122.146 1.66
+pept-CR8 1 C 2 N1 2 H 118.990 1.50
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-CR8 sp2_sp2_1 1 CA 1 C 2 N1 2 CA1 180.000 5.0 2
+pept-CR8 sp2_sp3_1 1 C 2 N1 2 CA1 2 C20 120.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-CR8 plan-3 1 CA 0.020
+pept-CR8 plan-3 1 C 0.020
+pept-CR8 plan-3 2 N1 0.020
+pept-CR8 plan-3 1 O 0.020
+pept-CR8 plan-11 1 C 0.020
+pept-CR8 plan-11 2 CA1 0.020
+pept-CR8 plan-11 2 H 0.020
+pept-CR8 plan-11 2 N1 0.020
+
+data_link_pept-CRO
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-CRO 1 C 2 N1 SINGLE 1.341 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-CRO 1 CA 1 C 2 N1 115.864 1.50
+pept-CRO 1 O 1 C 2 N1 123.257 1.50
+pept-CRO 2 CA1 2 N1 1 C 122.383 1.62
+pept-CRO 1 C 2 N1 2 H2 118.612 1.94
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-CRO sp2_sp2_1 1 CA 1 C 2 N1 2 CA1 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-CRO plan-2 1 CA 0.020
+pept-CRO plan-2 1 C 0.020
+pept-CRO plan-2 2 N1 0.020
+pept-CRO plan-2 1 O 0.020
+pept-CRO plan-3 2 CA1 0.020
+pept-CRO plan-3 1 C 0.020
+pept-CRO plan-3 2 H2 0.020
+pept-CRO plan-3 2 N1 0.020
+
+data_link_pept-GYC
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-GYC 1 C 2 N1 SINGLE 1.341 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-GYC 1 CA 1 C 2 N1 115.948 1.50
+pept-GYC 1 O 1 C 2 N1 123.341 1.50
+pept-GYC 2 CA1 2 N1 1 C 122.383 1.62
+pept-GYC 1 C 2 N1 2 H 118.612 1.94
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-GYC sp2_sp2_1 1 CA 1 C 2 N1 2 CA1 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-GYC plan-2 1 CA 0.020
+pept-GYC plan-2 1 C 0.020
+pept-GYC plan-2 2 N1 0.020
+pept-GYC plan-2 1 O 0.020
+pept-GYC plan-3 2 CA1 0.020
+pept-GYC plan-3 1 C 0.020
+pept-GYC plan-3 2 H 0.020
+pept-GYC plan-3 2 N1 0.020
+
+data_link_pept-NRQ
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-NRQ 1 C 2 N1 SINGLE 1.269 0.0173
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-NRQ 1 CA 1 C 2 N1 118.735 3.00
+pept-NRQ 1 O 1 C 2 N1 122.011 3.00
+pept-NRQ 2 CA1 2 N1 1 C 123.564 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-NRQ sp2_sp2_1 1 CA 1 C 2 N1 2 CA1 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-NRQ plan-2 1 CA 0.020
+pept-NRQ plan-2 1 C 0.020
+pept-NRQ plan-2 2 N1 0.020
+pept-NRQ plan-2 1 O 0.020
+
+data_link_pept-LYS
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-LYS 1 C 2 NZ SINGLE 1.329 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-LYS 1 CA 1 C 2 NZ 116.297 1.50
+pept-LYS 1 O 1 C 2 NZ 122.916 1.50
+pept-LYS 2 CE 2 NZ 1 C 122.788 1.80
+pept-LYS 1 C 2 NZ 2 HZ1 119.036 1.85
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-LYS sp2_sp2_1 1 CA 1 C 2 NZ 2 CE 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-LYS plan-1 1 CA 0.020
+pept-LYS plan-1 1 C 0.020
+pept-LYS plan-1 2 NZ 0.020
+pept-LYS plan-1 1 O 0.020
+pept-LYS plan-2 2 CE 0.020
+pept-LYS plan-2 1 C 0.020
+pept-LYS plan-2 2 HZ1 0.020
+pept-LYS plan-2 2 NZ 0.020
+
+data_link_pept-MDO
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-MDO 1 C 2 N1 SINGLE 1.341 0.0100
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-MDO 1 CA 1 C 2 N1 115.948 1.50
+pept-MDO 1 O 1 C 2 N1 123.341 1.50
+pept-MDO 2 CA1 2 N1 1 C 122.383 1.62
+pept-MDO 1 C 2 N1 2 H 118.612 1.94
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-MDO sp2_sp2_1 1 CA 1 C 2 N1 2 CA1 180.000 5.00 2
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-MDO plan-1 1 CA 0.020
+pept-MDO plan-1 1 C 0.020
+pept-MDO plan-1 2 N1 0.020
+pept-MDO plan-1 1 O 0.020
+pept-MDO plan-2 2 CA1 0.020
+pept-MDO plan-2 1 C 0.020
+pept-MDO plan-2 2 H 0.020
+pept-MDO plan-2 2 N1 0.020
+
+data_link_MS6-pept
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+MS6-pept 1 C 2 N SINGLE 1.336 0.0134
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+MS6-pept 1 CA 1 C 2 N 115.644 2.26
+MS6-pept 1 S 1 C 2 N 124.700 1.50
+MS6-pept 2 CA 2 N 1 C 122.248 2.99
+MS6-pept 1 C 2 N 2 H 118.454 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+MS6-pept sp2_sp2_1 1 CA 1 C 2 N 2 CA 180.000 5.0 2
+MS6-pept sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+MS6-pept plan-1 1 CA 0.020
+MS6-pept plan-1 1 C 0.020
+MS6-pept plan-1 2 N 0.020
+MS6-pept plan-1 1 S 0.020
+MS6-pept plan-2 1 C 0.020
+MS6-pept plan-2 2 CA 0.020
+MS6-pept plan-2 2 H 0.020
+MS6-pept plan-2 2 N 0.020
+
+data_link_pept-MS6
+loop_
+_chem_link_bond.link_id
+_chem_link_bond.atom_1_comp_id
+_chem_link_bond.atom_id_1
+_chem_link_bond.atom_2_comp_id
+_chem_link_bond.atom_id_2
+_chem_link_bond.type
+_chem_link_bond.value_dist
+_chem_link_bond.value_dist_esd
+pept-MS6 1 C 2 N SINGLE 1.338 0.0116
+
+loop_
+_chem_link_angle.link_id
+_chem_link_angle.atom_1_comp_id
+_chem_link_angle.atom_id_1
+_chem_link_angle.atom_2_comp_id
+_chem_link_angle.atom_id_2
+_chem_link_angle.atom_3_comp_id
+_chem_link_angle.atom_id_3
+_chem_link_angle.value_angle
+_chem_link_angle.value_angle_esd
+pept-MS6 1 CA 1 C 2 N 115.984 1.50
+pept-MS6 1 O 1 C 2 N 123.365 1.50
+pept-MS6 2 CA 2 N 1 C 123.404 3.00
+pept-MS6 1 C 2 N 2 H 119.057 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pept-MS6 sp2_sp2_1 1 CA 1 C 2 N 2 CA 180.000 5.0 2
+pept-MS6 sp2_sp3_1 1 C 2 N 2 CA 2 C 0.000 10.0 6
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pept-MS6 plan-1 1 CA 0.020
+pept-MS6 plan-1 1 C 0.020
+pept-MS6 plan-1 2 N 0.020
+pept-MS6 plan-1 1 O 0.020
+pept-MS6 plan-2 2 CA 0.020
+pept-MS6 plan-2 1 C 0.020
+pept-MS6 plan-2 2 H 0.020
+pept-MS6 plan-2 2 N 0.020
+
+data_mod_DG9m1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DG9m1 delete O4 . O OP -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DG9m1 delete P2A O4 single . . . .
+DG9m1 change O3 P2A single 1.485 0.0108 1.485 0.0108
+DG9m1 change P2A O4A double 1.485 0.0108 1.485 0.0108
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DG9m1 delete O3 P2A O4 . .
+DG9m1 delete O4A P2A O4 . .
+DG9m1 delete O6A P2A O4 . .
+DG9m1 change O3 P2A O4A 119.403 3.00
+DG9m1 change P2A O6A CCP 119.008 2.40
+
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+DG9m1 delete P2A O6A O3 O4 .
+
+data_mod_SERm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+SERm1 delete HG . H H 0
+SERm1 change OG . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+SERm1 delete OG HG single . . . .
+SERm1 change CA CB single 1.516 0.0100 1.516 0.0100
+SERm1 change CB OG single 1.438 0.0200 1.438 0.0200
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+SERm1 delete CB OG HG . .
+SERm1 change CA CB OG 108.381 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+SERm1 delete CA CB OG HG . . . 3
+SERm1 change OG CB CA N sp3_sp3_199 180.000 10.0 3
+
+data_mod_CYS-SS
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+CYS-SS delete HG . . . .000
+
+data_mod_CYSmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+CYSmod1 delete HG . H HSH1 0
+CYSmod1 change SG . S S2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+CYSmod1 delete SG HG single . . . .
+CYSmod1 change CB HB3 single 0.980 0.0104 1.089 0.0100
+CYSmod1 change CB HB2 single 0.980 0.0104 1.089 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+CYSmod1 delete CB SG HG . .
+CYSmod1 change N CA CB 109.354 2.20
+CYSmod1 change C CA CB 110.419 3.00
+CYSmod1 change CA CB SG 114.974 2.42
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+CYSmod1 delete CA CB SG HG . . . 0
+CYSmod1 change N CA CB SG sp3_sp3_19 180.000 10.0 3
+
+data_mod_MPRm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+MPRm1 delete HS3 . H HSH1 0
+MPRm1 change S3 . S S2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+MPRm1 delete S3 HS3 single . . . .
+MPRm1 change C3 S3 single 1.817 0.0100 1.817 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+MPRm1 delete C3 S3 HS3 . .
+MPRm1 change C2 C3 S3 112.476 3.00
+MPRm1 change S3 C3 H31 108.769 1.50
+MPRm1 change S3 C3 H32 108.769 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+MPRm1 delete C2 C3 S3 HS3 . .
+
+data_mod_FORm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+FORm1 delete H2 . H H 0
+FORm1 change C . C C1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+FORm1 delete C H2 single . . . .
+FORm1 change C O double 1.229 0.0100 1.229 0.0100
+FORm1 change C H1 single 0.947 0.0100 1.082 0.0130
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+FORm1 delete O C H2 . .
+FORm1 delete H1 C H2 . .
+FORm1 change O C H1 118.402 3.00
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+FORm1 delete plan-1 C 0.020
+FORm1 delete plan-1 H1 0.020
+FORm1 delete plan-1 H2 0.020
+FORm1 delete plan-1 O 0.020
+
+data_mod_NH3
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+NH3 change N N . NT3 -1.000
+NH3 add H H H HNT3 .000
+NH3 add . H2 H HNT3 .000
+NH3 add . H3 H HNT3 .000
+NH3 delete HN1 . . . .000
+NH3 delete HN2 . . . .000
+NH3 delete HN3 . . . .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+NH3 change N n/a . CA START
+NH3 add H N . . .
+NH3 add H2 N . . .
+NH3 add H3 N . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+NH3 add N H2 single 0.914 0.010 1.036 0.016
+NH3 add N H3 single 0.914 0.010 1.036 0.016
+NH3 change N CA single 1.491 .021 1.491 .021
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+NH3 add H2 N H3 109.470 3.000
+NH3 add H3 N CA 109.470 3.000
+NH3 add H2 N CA 109.470 3.000
+NH3 add H N H2 109.470 3.000
+NH3 add H N H3 109.470 3.000
+NH3 change H N CA 109.470 3.000
+
+data_mod_NH1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+NH1 change N N . NH1 .000
+NH1 add . H H HNH1 .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+NH1 change N n/a . CA START
+NH1 add H N . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+NH1 add N H single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+NH1 add H N CA 109.307 3.000
+NH1 add H N CD 106.136 2.250
+
+data_mod_NH2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+NH2 change N N . NH1 .000
+NH2 add . H H HNH1 .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+NH2 change N n/a . CA START
+NH2 add H N . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+NH2 add N H single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+NH2 add H N CA 109.307 3.000
+NH2 add H N CD 106.136 2.250
+
+data_mod_ACEmod
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+ACEmod delete H . . . .000
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+ACEmod delete C H single . . . .
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+ACEmod delete O C H . .
+ACEmod delete CH3 C H . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+ACEmod delete plan-1 C 0.020
+ACEmod delete plan-1 CH3 0.020
+ACEmod delete plan-1 H 0.020
+ACEmod delete plan-1 O 0.020
+
+data_mod_NH2N
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+NH2N change N N . NH2 .000
+
+data_mod_COO
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+COO change C C . C .000
+COO change O O . OC -.500
+COO add . OXT O OC -.500
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+COO add OXT C . . END
+COO change C n/a . OXT .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+COO change C O deloc 1.231 .020 1.231 .020
+COO add C OXT deloc 1.231 .020 1.231 .020
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+COO change CA C O 121.000 3.000
+COO add CA C OXT 121.000 3.000
+COO add O C OXT 118.000 3.000
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.id
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+COO add psi N CA C OXT 160.00 30.0 2
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+COO add oxt C .020
+COO add oxt CA .020
+COO add oxt O .020
+COO add oxt OXT .020
+
+data_mod_AA-STAND
+
+data_mod_AA-STPRO
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+AA-STPRO delete HN . . . .000
+
+data_mod_NA-STAND
+
+data_mod_5*END
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+5*END delete P . . . .000
+5*END delete OP1 . . . .000
+5*END delete OP2 . . . .000
+5*END delete OP3 . . . .000
+5*END change 'O5'' 'O5'' . OH1 0.000
+5*END add . 'HO5'' H HOH1 0.000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+5*END delete P n/a . . .
+5*END delete O1P n/a . . .
+5*END delete O2P n/a . . .
+5*END change 'O5'' n/a . 'C5'' START
+5*END add 'HO5'' 'O5'' . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+5*END add 'O5'' 'HO5'' single 0.839 0.010 0.970 0.012
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+5*END add 'C5'' 'O5'' 'HO5'' 120.000 3.000
+
+data_mod_3*END
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+3*END change 'O3'' 'O3'' . OH1 0.000
+3*END add . 'HO3'' H HOH1 0.000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+3*END change 'O3'' 'C3'' . . END
+3*END add 'HO3'' 'O3'' . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+3*END add 'O3'' 'HO3'' single 0.839 0.010 0.970 0.012
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+3*END add 'C3'' 'O3'' 'HO3'' 120.000 3.000
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.id
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+3*END add hh 'C4'' 'C3'' 'O3'' 'HO3'' .00 30.0 3
+
+data_mod_p5*END
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+p5*END change OP3 OP3 O OP -.330
+
+data_mod_p3*END
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+p3*END change 'O3'' 'O3'' . OH1 0.000
+p3*END add . 'HO3'' H HOH1 0.000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+p3*END change 'O3'' 'C3'' . . END
+p3*END add 'HO3'' 'O3'' . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+p3*END add 'O3'' 'HO3'' single 0.839 0.010 0.970 0.012
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+p3*END add 'C3'' 'O3'' 'HO3'' 120.000 3.000
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.id
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+p3*END add hh 'C4'' 'C3'' 'O3'' 'HO3'' .00 30.0 3
+
+data_mod_DEL_OP3
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL_OP3 delete OP3 . O OP -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL_OP3 delete OP3 P single . . . .
+DEL_OP3 change P OP1 double 1.491 0.0100 1.491 0.0100
+DEL_OP3 change P OP2 single 1.491 0.0100 1.491 0.0100
+DEL_OP3 change P "O5'" single 1.599 0.0103 1.599 0.0103
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL_OP3 delete OP3 P OP1 . .
+DEL_OP3 delete OP3 P OP2 . .
+DEL_OP3 delete OP3 P "O5'" . .
+DEL_OP3 change OP1 P OP2 118.304 1.50
+DEL_OP3 change OP1 P "O5'" 108.008 3.00
+DEL_OP3 change OP2 P "O5'" 108.008 3.00
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL_OP3 delete "C5'" "O5'" P OP3 . .
+
+data_mod_DEL_HO3p
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL_HO3p delete "HO3'" . H H 0
+DEL_HO3p change "O3'" . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL_HO3p delete "O3'" "HO3'" single . . . .
+DEL_HO3p change "C3'" "O3'" single 1.421 0.0119 1.421 0.0119
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL_HO3p delete "C3'" "O3'" "HO3'" . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL_HO3p delete "C4'" "C3'" "O3'" "HO3'" . .
+
+data_mod_F86m1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+F86m1 delete O7 . O O -1
+F86m1 change O5 . O O 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+F86m1 delete P1 O7 double . . . .
+F86m1 change O4 P1 single 1.599 0.0103 1.599 0.0103
+F86m1 change O6 P1 single 1.491 0.0100 1.491 0.0100
+F86m1 change O5 P1 double 1.491 0.0100 1.491 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+F86m1 delete O4 P1 O7 . .
+F86m1 delete O6 P1 O7 . .
+F86m1 delete O5 P1 O7 . .
+F86m1 change O4 P1 O6 108.008 3.00
+F86m1 change O5 P1 O4 108.008 3.00
+F86m1 change O5 P1 O6 118.304 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+F86m1 delete C6 O4 P1 O7 . .
+
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+F86m1 delete P1 O4 O5 O6 .
+
+data_mod_FOR-N
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+FOR-N add . H H HC1 .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+FOR-N add H C . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+FOR-N add C H single 0.988 0.010 1.089 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+FOR-N add H C O 121.000 3.000
+
+data_mod_FOR-C
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+FOR-C change O O . OC -0.500
+FOR-C add . OXT O OC -0.500
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+FOR-C add OXT C . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+FOR-C change C O deloc 1.231 .020 1.231 .020
+FOR-C add C OXT deloc 1.231 .020 1.231 .020
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+FOR-C add O C OXT 120.000 3.000
+
+data_mod_G-N2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+G-N2 delete N2 . . . .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+G-N2 delete N2 n/a . . .
+
+data_mod_DEL-O1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-O1 delete O1 . O OH1 0
+DEL-O1 delete HO1 . H H 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-O1 delete C1 O1 single . . . .
+DEL-O1 delete O1 HO1 single . . . .
+DEL-O1 change C1 C2 single 1.523 0.0113 1.523 0.0113
+DEL-O1 change C1 O5 single 1.426 0.0100 1.426 0.0100
+DEL-O1 change C1 H1 single 0.992 0.0108 1.089 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-O1 delete C2 C1 O1 . .
+DEL-O1 delete O1 C1 O5 . .
+DEL-O1 delete O1 C1 H1 . .
+DEL-O1 delete C1 O1 HO1 . .
+DEL-O1 change C2 C1 O5 110.285 1.56
+DEL-O1 change C2 C1 H1 109.493 1.50
+DEL-O1 change O5 C1 H1 109.051 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+DEL-O1 delete C2 C1 O1 HO1 . . . 0
+DEL-O1 delete O5 C1 O1 HO1 . . . 0
+DEL-O1 delete H1 C1 O1 HO1 . . . 0
+DEL-O1 change C5 O5 C1 C2 nu08 -56.178 10.0 3
+DEL-O1 change O5 C1 C2 C3 nu18 52.105 10.0 3
+
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+DEL-O1 delete C1 O5 O1 C2 .
+
+data_mod_DELk-O2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DELk-O2 delete O2 . O OH1 0
+DELk-O2 delete HO2 . H H 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DELk-O2 delete C2 O2 single . . . .
+DELk-O2 delete O2 HO2 single . . . .
+DELk-O2 change C1 C2 single 1.521 0.0200 1.521 0.0200
+DELk-O2 change C2 C3 single 1.524 0.0175 1.524 0.0175
+DELk-O2 change C2 O6 single 1.414 0.0142 1.414 0.0142
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DELk-O2 delete C1 C2 O2 . .
+DELk-O2 delete O2 C2 C3 . .
+DELk-O2 delete O2 C2 O6 . .
+DELk-O2 delete C2 O2 HO2 . .
+DELk-O2 change C1 C2 C3 110.878 3.00
+DELk-O2 change C1 C2 O6 108.071 3.00
+DELk-O2 change C3 C2 O6 110.815 2.73
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+DELk-O2 delete O1A C1 C2 O2 . . . 0
+DELk-O2 delete C1 C2 O2 HO2 . . . 0
+DELk-O2 change C1 C2 C3 C4 sp3_sp3_43 60.000 10.0 3
+DELk-O2 change C1 C2 O6 C6 sp3_sp3_119 60.000 10.0 3
+
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+DELk-O2 delete C2 O6 O2 C1 .
+
+data_mod_DEL-HO1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HO1 delete HO1 . H H 0
+DEL-HO1 change O1 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HO1 delete O1 HO1 single . . . .
+DEL-HO1 change C1 O1 single 1.396 0.0113 1.396 0.0113
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HO1 delete C1 O1 HO1 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-HO1 delete C2 C1 O1 HO1 . .
+DEL-HO1 delete O5 C1 O1 HO1 . .
+DEL-HO1 delete H1 C1 O1 HO1 . .
+
+data_mod_DEL-HO2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HO2 delete HO2 . H H 0
+DEL-HO2 change O2 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HO2 delete O2 HO2 single . . . .
+DEL-HO2 change C2 O2 single 1.448 0.0100 1.448 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HO2 delete C2 O2 HO2 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-HO2 delete C1 C2 O2 HO2 . .
+DEL-HO2 delete C3 C2 O2 HO2 . .
+DEL-HO2 delete H2 C2 O2 HO2 . .
+
+data_mod_DEL-HO3
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HO3 delete HO3 . H H 0
+DEL-HO3 change O3 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HO3 delete O3 HO3 single . . . .
+DEL-HO3 change C3 O3 single 1.433 0.0151 1.433 0.0151
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HO3 delete C3 O3 HO3 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-HO3 delete C2 C3 O3 HO3 . .
+DEL-HO3 delete C4 C3 O3 HO3 . .
+DEL-HO3 delete H3 C3 O3 HO3 . .
+
+data_mod_DEL-HO6
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HO6 delete HO6 . H H 0
+DEL-HO6 change O6 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HO6 delete O6 HO6 single . . . .
+DEL-HO6 change C6 O6 single 1.441 0.0183 1.441 0.0183
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HO6 delete C6 O6 HO6 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-HO6 delete C5 C6 O6 HO6 . .
+DEL-HO6 delete H61 C6 O6 HO6 . .
+DEL-HO6 delete H62 C6 O6 HO6 . .
+
+data_mod_DEL-HO8
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HO8 delete HO8 . H H 0
+DEL-HO8 change O8 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HO8 delete O8 HO8 single . . . .
+DEL-HO8 change C8 O8 single 1.432 0.0179 1.432 0.0179
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HO8 delete C8 O8 HO8 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-HO8 delete C7 C8 O8 HO8 . .
+
+data_mod_DEL-HO7
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HO7 delete HO7 . H H 0
+DEL-HO7 change O7 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HO7 delete O7 HO7 single . . . .
+DEL-HO7 change C7 O7 single 1.433 0.0181 1.433 0.0181
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HO7 delete C7 O7 HO7 . .
+
+data_mod_DEL-HO4
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HO4 delete HO4 . H H 0
+DEL-HO4 change O4 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HO4 delete O4 HO4 single . . . .
+DEL-HO4 change C4 O4 single 1.433 0.0151 1.433 0.0151
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HO4 delete C4 O4 HO4 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-HO4 delete C3 C4 O4 HO4 . .
+DEL-HO4 delete C5 C4 O4 HO4 . .
+DEL-HO4 delete H4 C4 O4 HO4 . .
+
+data_mod_DELk-HO4
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DELk-HO4 delete HO4 . H H 0
+DELk-HO4 change O4 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DELk-HO4 delete O4 HO4 single . . . .
+DELk-HO4 change C4 O4 single 1.448 0.0181 1.448 0.0181
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DELk-HO4 delete C4 O4 HO4 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DELk-HO4 delete C3 C4 O4 HO4 . .
+
+data_mod_DEL-HO5
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HO5 delete HO5 . H H 0
+DEL-HO5 change O5 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HO5 delete O5 HO5 single . . . .
+DEL-HO5 change C5 O5 single 1.433 0.0151 1.433 0.0151
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HO5 delete C5 O5 HO5 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-HO5 delete C4 C5 O5 HO5 . .
+
+data_mod_DEL-HD1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+DEL-HD1 delete HD1 . . . .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+DEL-HD1 change ND1 n/a . . END
+
+data_mod_DEL-HE2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+DEL-HE2 delete HE2 . . . .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+DEL-HE2 change NE2 n/a . . END
+
+data_mod_DEL-OXT
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-OXT delete OXT . O OC -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-OXT delete C OXT single . . . .
+DEL-OXT change CA C single 1.526 0.010 1.526 0.010
+DEL-OXT change C O double 1.229 0.012 1.229 0.012
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-OXT delete CA C OXT . .
+DEL-OXT delete O C OXT . .
+DEL-OXT change CA C O 120.614 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+DEL-OXT delete plan-1 C 0.020
+DEL-OXT delete plan-1 CA 0.020
+DEL-OXT delete plan-1 O 0.020
+DEL-OXT delete plan-1 OXT 0.020
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-OXT delete O C CA N 0.000 10.0
+
+data_mod_DEL-OXT1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-OXT1 delete OXT . O OC -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-OXT1 delete C OXT single . . . .
+DEL-OXT1 change CA C single 1.526 0.010 1.526 0.010
+DEL-OXT1 change C O double 1.232 0.010 1.232 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-OXT1 delete CA C OXT . .
+DEL-OXT1 delete O C OXT . .
+DEL-OXT1 change CA C O 120.082 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+DEL-OXT1 delete plan-1 C 0.020
+DEL-OXT1 delete plan-1 CA 0.020
+DEL-OXT1 delete plan-1 O 0.020
+DEL-OXT1 delete plan-1 OXT 0.020
+
+data_mod_DEL-HN1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HN1 delete H2 . H H 0
+DEL-HN1 delete H3 . H H 0
+DEL-HN1 change N . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HN1 delete N H2 single . . . .
+DEL-HN1 delete N H3 single . . . .
+DEL-HN1 change CA N single 1.453 0.010 1.453 0.010
+DEL-HN1 change N H single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HN1 delete CA N H2 . .
+DEL-HN1 delete CA N H3 . .
+DEL-HN1 delete H N H2 . .
+DEL-HN1 delete H N H3 . .
+DEL-HN1 delete H2 N H3 . .
+DEL-HN1 change CA N H 118.729 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+DEL-HN1 delete C CA N H 180 10
+
+data_mod_DEL-NMH
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-NMH delete H . H H 0
+DEL-NMH change N . N N 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-NMH delete N H single . . . .
+DEL-NMH change N CN single 1.450 0.0200 1.450 0.0200
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-NMH delete CN N H . .
+DEL-NMH delete CA N H . .
+DEL-NMH change CN N CA 118.119 2.78
+DEL-NMH change N CA C 111.097 3.00
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+DEL-NMH change CN N CA C sp2_sp3_13 0.000 10.0 6
+DEL-NMH change CA N CN HN1 sp2_sp3_7 0.000 10.0 6
+
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+DEL-NMH delete N CA CN H .
+
+data_mod_DEL-HNP
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+DEL-HNP delete H . H H 0
+DEL-HNP delete H2 . H H 0
+DEL-HNP change N . N NH0 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HNP delete N H single . . . .
+DEL-HNP delete N H2 single . . . .
+DEL-HNP change N CA single 1.459 0.0100 1.459 0.0100
+DEL-HNP change N CD single 1.472 0.0100 1.472 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HNP delete CA N H . .
+DEL-HNP delete CA N H2 . .
+DEL-HNP delete CD N H . .
+DEL-HNP delete CD N H2 . .
+DEL-HNP delete H N H2 . .
+DEL-HNP change CA N CD 112.597 1.50
+DEL-HNP change N CA C 113.251 1.50
+DEL-HNP change N CD CG 102.887 1.50
+
+data_mod_SUImod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+SUImod1 delete H2 . H H 0
+SUImod1 delete H1 . H H 0
+SUImod1 change N . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+SUImod1 delete N H2 single . . . .
+SUImod1 delete N H1 single . . . .
+SUImod1 change N CA single 1.447 0.0100 1.447 0.0100
+SUImod1 change N H single 0.875 0.0126 1.016 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+SUImod1 delete CA N H2 . .
+SUImod1 delete CA N H1 . .
+SUImod1 delete H2 N H . .
+SUImod1 delete H2 N H1 . .
+SUImod1 delete H N H1 . .
+SUImod1 change CA N H 119.750 2.24
+SUImod1 change N CA CB 114.845 1.50
+SUImod1 change N CA C1 111.533 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+SUImod1 delete CB CA N H2 . . . 3
+
+data_mod_SUImod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+SUImod2 delete OXT . O OC -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+SUImod2 delete C OXT single . . . .
+SUImod2 change C2A C single 1.516 0.0100 1.516 0.0100
+SUImod2 change C O double 1.221 0.0162 1.221 0.0162
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+SUImod2 delete C2A C OXT . .
+SUImod2 delete O C OXT . .
+SUImod2 change CG N2 C2A 123.734 2.62
+SUImod2 change C1 N2 C2A 123.734 2.62
+SUImod2 change N2 C2A C 112.256 3.00
+SUImod2 change C C2A H2A 105.836 3.00
+SUImod2 change C C2A H2B 105.836 3.00
+SUImod2 change H2A C2A H2B 108.644 3.00
+SUImod2 change C2A C O 121.567 3.00
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+SUImod2 delete plan-4 C 0.020
+SUImod2 delete plan-4 C2A 0.020
+SUImod2 delete plan-4 O 0.020
+SUImod2 delete plan-4 OXT 0.020
+
+data_mod_SUG-b-L
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+SUG-b-L change C5 C4 O5 C6 negativ
+SUG-b-L change C1 O1 O5 C2 positiv
+
+data_mod_SUG-a-D
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+SUG-a-D change C5 C4 O5 C6 positiv
+SUG-a-D change C1 O1 O5 C2 negativ
+
+data_mod_SUG-b-D
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+SUG-b-D change C5 C4 O5 C6 positiv
+SUG-b-D change C1 O1 O5 C2 positiv
+
+data_mod_SUG-a-L
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+SUG-a-L change C5 C4 O5 C6 negativ
+SUG-a-L change C1 O1 O5 C2 negativ
+
+data_mod_O1MET
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+O1MET change O1 . . O2 .000
+O1MET delete HO1 . . . .000
+O1MET add . CM C CH3 .000
+O1MET add . HM1 H HCH .000
+O1MET add . HM2 H HGH .000
+O1MET add . HM3 H HCH .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+O1MET change O1 C1 . CM .
+O1MET delete HO1 n/a . . .
+O1MET add CM O1 . HM3 .
+O1MET add HM1 CM . . .
+O1MET add HM2 CM . . .
+O1MET add HM3 CM . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+O1MET add O1 CM single 1.420 .020 1.420 .020
+O1MET add CM HM1 single 0.988 0.010 1.089 0.010
+O1MET add CM HM2 single 0.988 0.010 1.089 0.010
+O1MET add CM HM3 single 0.988 0.010 1.089 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+O1MET add C1 O1 CM 120.000 3.000
+O1MET add O1 CM HM1 109.470 3.000
+O1MET add O1 CM HM2 109.470 3.000
+O1MET add O1 CM HM3 109.470 3.000
+O1MET add HM2 CM HM1 109.470 3.000
+O1MET add HM3 CM HM1 109.470 3.000
+O1MET add HM3 CM HM2 109.470 3.000
+
+data_mod_PEPT-D
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+PEPT-D change CA N CB C positiv
+
+data_mod_1MA
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+1MA change N1 . . NR6 .000
+1MA add . C1 C CH3 .000
+1MA add . H11 H HCH .000
+1MA add . H12 H HGH .000
+1MA add . H13 H HCH .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+1MA add C1 N1 . H13 .
+1MA add H11 C1 . . .
+1MA add H12 C1 . . .
+1MA add H13 C1 . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+1MA add C1 N1 single 1.465 .020 1.465 .020
+1MA add C1 H11 single 0.988 0.010 1.089 0.010
+1MA add C1 H12 single 0.988 0.010 1.089 0.010
+1MA add C1 H13 single 0.988 0.010 1.089 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+1MA add N1 C1 H11 109.470 3.000
+1MA add N1 C1 H12 109.470 3.000
+1MA add N1 C1 H13 109.470 3.000
+1MA add H12 C1 H11 109.470 3.000
+1MA add H13 C1 H11 109.470 3.000
+1MA add H13 C1 H12 109.470 3.000
+
+data_mod_1MG
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+1MG change N1 . . NR6 .000
+1MG add . C1A C CH3 .000
+1MG add . H1A1 H HCH .000
+1MG add . H1A2 H HGH .000
+1MG add . H1A3 H HCH .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+1MG add C1A N1 . H1A3 .
+1MG add H1A1 C1A . . .
+1MG add H1A2 C1A . . .
+1MG add H1A3 C1A . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+1MG add C1A N1 single 1.465 .020 1.465 .020
+1MG add C1A H1A1 single 0.988 0.010 1.089 0.010
+1MG add C1A H1A2 single 0.988 0.010 1.089 0.010
+1MG add C1A H1A3 single 0.988 0.010 1.089 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+1MG add N1 C1A H1A1 109.470 3.000
+1MG add N1 C1A H1A2 109.470 3.000
+1MG add N1 C1A H1A3 109.470 3.000
+1MG add H1A2 C1A H1A1 109.470 3.000
+1MG add H1A3 C1A H1A1 109.470 3.000
+1MG add H1A3 C1A H1A2 109.470 3.000
+
+data_mod_2MG
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+2MG change N2 . . NH1 .000
+2MG add . C2A C CH3 .000
+2MG add . H2A1 H HCH .000
+2MG add . H2A2 H HGH .000
+2MG add . H2A3 H HCH .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+2MG change N2 C2 . C2A .
+2MG add C2A N2 . H2A3 .
+2MG add H2A1 C2A . . .
+2MG add H2A2 C2A . . .
+2MG add H2A3 C2A . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+2MG add C2A N2 single 1.465 .020 1.465 .020
+2MG add C2A H2A1 single 0.988 0.010 1.089 0.010
+2MG add C2A H2A2 single 0.988 0.010 1.089 0.010
+2MG add C2A H2A3 single 0.988 0.010 1.089 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+2MG add C2 N2 C2A 115.000 3.000
+2MG add N2 C2A H2A1 109.470 3.000
+2MG add N2 C2A H2A2 109.470 3.000
+2MG add N2 C2A H2A3 109.470 3.000
+2MG add H2A2 C2A H2A1 109.470 3.000
+2MG add H2A3 C2A H2A1 109.470 3.000
+2MG add H2A3 C2A H2A2 109.470 3.000
+
+data_mod_M2G
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+M2G change N2 . . N .000
+M2G add . C2A C CH3 .000
+M2G add . H2A1 H HCH .000
+M2G add . H2A2 H HGH .000
+M2G add . H2A3 H HCH .000
+M2G add . C2B C CH3 .000
+M2G add . H2B1 H HCH .000
+M2G add . H2B2 H HGH .000
+M2G add . H2B3 H HCH .000
+M2G delete H21 . . . .000
+M2G delete H22 . . . .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+M2G change N2 C2 . C2A .
+M2G add C2A N2 . H2A3 .
+M2G add H2A1 C2A . . .
+M2G add H2A2 C2A . . .
+M2G add H2A3 C2A . . .
+M2G add C2B N2 . H2B3 .
+M2G add H2B1 C2B . . .
+M2G add H2B2 C2B . . .
+M2G add H2B3 C2B . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+M2G add C2A N2 single 1.465 .020 1.465 .020
+M2G add C2A H2A1 single 0.988 0.010 1.089 0.010
+M2G add C2A H2A2 single 0.988 0.010 1.089 0.010
+M2G add C2A H2A3 single 0.988 0.010 1.089 0.010
+M2G add C2B N2 single 1.465 .020 1.465 .020
+M2G add C2B H2B1 single 0.988 0.010 1.089 0.010
+M2G add C2B H2B2 single 0.988 0.010 1.089 0.010
+M2G add C2B H2B3 single 0.988 0.010 1.089 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+M2G add C2 N2 C2A 118.000 3.000
+M2G add C2 N2 C2B 118.000 3.000
+M2G add C2A N2 C2B 124.000 3.000
+M2G add N2 C2A H2A1 109.470 3.000
+M2G add N2 C2A H2A2 109.470 3.000
+M2G add N2 C2A H2A3 109.470 3.000
+M2G add H2A2 C2A H2A1 109.470 3.000
+M2G add H2A3 C2A H2A1 109.470 3.000
+M2G add H2A3 C2A H2A2 109.470 3.000
+M2G add N2 C2B H2B1 109.470 3.000
+M2G add N2 C2B H2B2 109.470 3.000
+M2G add N2 C2B H2B3 109.470 3.000
+M2G add H2B2 C2B H2B1 109.470 3.000
+M2G add H2B3 C2B H2B1 109.470 3.000
+M2G add H2B3 C2B H2B2 109.470 3.000
+
+data_mod_O2*MET
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+O2*MET change 'O2'' . . OC2 .000
+O2*MET delete 'HO2'' . . . .000
+O2*MET add . C2A C CH3 .000
+O2*MET add . H2A1 H HCH .000
+O2*MET add . H2A2 H HGH .000
+O2*MET add . H2A3 H HCH .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+O2*MET change 'O2'' 'C2'' . C2A .
+O2*MET add C2A 'O2'' . H2A3 .
+O2*MET add H2A1 C2A . . .
+O2*MET add H2A2 C2A . . .
+O2*MET add H2A3 C2A . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+O2*MET add 'O2'' C2A single 1.420 .020 1.420 .020
+O2*MET add C2A H2A1 single 0.988 0.010 1.089 0.010
+O2*MET add C2A H2A2 single 0.988 0.010 1.089 0.010
+O2*MET add C2A H2A3 single 0.988 0.010 1.089 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+O2*MET add 'C2'' 'O2'' C2A 120.000 3.000
+O2*MET add 'O2'' C2A H2A1 109.470 3.000
+O2*MET add 'O2'' C2A H2A2 109.470 3.000
+O2*MET add 'O2'' C2A H2A3 109.470 3.000
+O2*MET add H2A2 C2A H2A1 109.470 3.000
+O2*MET add H2A3 C2A H2A1 109.470 3.000
+O2*MET add H2A3 C2A H2A2 109.470 3.000
+
+data_mod_C5MET
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+C5MET change C5 . . CR6 .000
+C5MET add . C5A C CH3 .000
+C5MET add . H5A1 H HCH .000
+C5MET add . H5A2 H HGH .000
+C5MET add . H5A3 H HCH .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+C5MET add C5A C5 . H5A3 .
+C5MET add H5A1 C5A . . .
+C5MET add H5A2 C5A . . .
+C5MET add H5A3 C5A . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+C5MET add C5A C5 single 1.500 .020 1.500 .020
+C5MET add C5A H5A1 single 0.988 0.010 1.089 0.010
+C5MET add C5A H5A2 single 0.988 0.010 1.089 0.010
+C5MET add C5A H5A3 single 0.988 0.010 1.089 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+C5MET add C4 C5 C5A 122.000 3.000
+C5MET add C6 C5 C5A 118.000 3.000
+C5MET add C5 C5A H5A2 109.470 3.000
+C5MET add C5 C5A H5A3 109.470 3.000
+C5MET add H5A2 C5A H5A1 109.470 3.000
+C5MET add H5A3 C5A H5A1 109.470 3.000
+C5MET add H5A3 C5A H5A2 109.470 3.000
+
+data_mod_N7MET
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+N7MET change N7 . . NR5 .000
+N7MET add . C7 C CH3 .000
+N7MET add . H71 H HCH .000
+N7MET add . H72 H HGH .000
+N7MET add . H73 H HCH .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+N7MET add C7 N7 . H73 .
+N7MET add H71 C7 . . .
+N7MET add H72 C7 . . .
+N7MET add H73 C7 . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+N7MET add C7 N7 single 1.465 .020 1.465 .020
+N7MET add C7 H71 single 0.988 0.010 1.089 0.010
+N7MET add C7 H72 single 0.988 0.010 1.089 0.010
+N7MET add C7 H73 single 0.988 0.010 1.089 0.010
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+N7MET add C5 N7 C7 126.000 3.000
+N7MET add C8 N7 C7 126.000 3.000
+N7MET add N7 C7 H71 109.470 3.000
+N7MET add N7 C7 H72 109.470 3.000
+N7MET add N7 C7 H73 109.470 3.000
+N7MET add H72 C7 H71 109.470 3.000
+N7MET add H73 C7 H71 109.470 3.000
+N7MET add H73 C7 H72 109.470 3.000
+
+data_mod_RNA-O2*
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+RNA-O2* delete 'O2'' . . . .000
+RNA-O2* delete 'HO2'' . . . .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+RNA-O2* delete 'O2'' n/a . . .
+RNA-O2* delete 'HO2'' n/a . . .
+
+data_mod_XYS-O1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+XYS-O1 delete O1 . . . .000
+XYS-O1 delete HO1 . . . .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+XYS-O1 delete O1 n/a . . .
+XYS-O1 delete HO1 n/a . . .
+
+data_mod_B2C
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+B2C change N N . NT3 -1.000
+B2C add . H1 H HNT3 0.000
+B2C add . H2 H HNT3 0.000
+B2C add . H3 H HNT3 0.000
+B2C delete H . . . .000
+B2C change C B B B .000
+B2C change O O1 O O .000
+B2C add . O2 O O .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+B2C change N n/a . CA START
+B2C add H1 N . . .
+B2C add H2 N . . .
+B2C add H3 N . . .
+B2C change B CA . . END
+B2C change CA N . B .
+B2C change O1 B . . .
+B2C add O2 B . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+B2C add N H1 single 0.914 0.010 1.036 0.016
+B2C add N H2 single 0.914 0.010 1.036 0.016
+B2C add N H3 single 0.914 0.010 1.036 0.016
+B2C change N CA single 1.491 .021 1.491 .021
+B2C change B CA single 1.560 .020 1.560 .020
+B2C change B O1 deloc 1.480 .020 1.480 .020
+B2C add B O2 deloc 1.480 .020 1.480 .020
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+B2C add H2 N H3 109.470 3.000
+B2C add H3 N CA 109.470 3.000
+B2C add H2 N CA 109.470 3.000
+B2C add H1 N H2 109.470 3.000
+B2C add H1 N H3 109.470 3.000
+B2C add H1 N CA 109.470 3.000
+B2C add O1 B O2 112.000 3.000
+B2C change CA B O1 126.000 3.000
+B2C add CA B O2 126.000 3.000
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.id
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+B2C add hhb N CA B O2 .00 30.0 3
+
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+B2C change CA N CB B negativ
+
+data_mod_B2C_D
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+B2C_D change N N . NT3 -1.000
+B2C_D add . H1 H HNT3 0.000
+B2C_D add . H2 H HNT3 0.00
+B2C_D add . H3 H HNT3 0.00
+B2C_D delete H . . . .000
+B2C_D change C B B B .000
+B2C_D change O O1 O O .000
+B2C_D add . O2 O O .000
+
+loop_
+_chem_mod_tree.mod_id
+_chem_mod_tree.function
+_chem_mod_tree.atom_id
+_chem_mod_tree.atom_back
+_chem_mod_tree.back_type
+_chem_mod_tree.atom_forward
+_chem_mod_tree.connect_type
+B2C_D change N n/a . CA START
+B2C_D add H1 N . . .
+B2C_D add H2 N . . .
+B2C_D add H3 N . . .
+B2C_D change B CA . . END
+B2C_D change CA N . B .
+B2C_D change O1 B . . .
+B2C_D add O2 B . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+B2C_D add N H1 single 0.914 0.010 1.036 0.016
+B2C_D add N H2 single 0.914 0.010 1.036 0.016
+B2C_D add N H3 single 0.914 0.010 1.036 0.016
+B2C_D change N CA single 1.491 .021 1.491 .021
+B2C_D change B CA single 1.560 .020 1.560 .020
+B2C_D change B O1 deloc 1.480 .020 1.480 .020
+B2C_D add B O2 deloc 1.480 .020 1.480 .020
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+B2C_D add H2 N H3 109.470 3.000
+B2C_D add H3 N CA 109.470 3.000
+B2C_D add H2 N CA 109.470 3.000
+B2C_D add H1 N H2 109.470 3.000
+B2C_D add H1 N H3 109.470 3.000
+B2C_D add H1 N CA 109.470 3.000
+B2C_D add O1 B O2 112.000 3.000
+B2C_D change CA B O1 126.000 3.000
+B2C_D add CA B O2 126.000 3.000
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.id
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+B2C_D add hhb N CA B O2 .00 30.0 3
+
+loop_
+_chem_mod_chir.mod_id
+_chem_mod_chir.function
+_chem_mod_chir.atom_id_centre
+_chem_mod_chir.atom_id_1
+_chem_mod_chir.atom_id_2
+_chem_mod_chir.atom_id_3
+_chem_mod_chir.new_volume_sign
+B2C_D change CA N CB B positiv
+
+data_mod_RENAME
+
+data_mod_TERMINUS
+
+data_mod_DEL-HD22
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+DEL-HD22 delete HD22 . . . .000
+
+data_mod_DEL-HG
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+DEL-HG delete HG . . . .000
+
+data_mod_DEL-HG1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+DEL-HG1 delete HG1 . . . .000
+
+data_mod_ACYmod
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+ACYmod delete H3 . H H 0
+ACYmod change CH3 . C CH2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+ACYmod delete CH3 H3 single . . . .
+ACYmod change C CH3 single 1.529 0.0130 1.529 0.0130
+ACYmod change CH3 H1 single 0.977 0.0109 1.089 0.0100
+ACYmod change CH3 H2 single 0.977 0.0109 1.089 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+ACYmod delete C CH3 H3 . .
+ACYmod delete H1 CH3 H3 . .
+ACYmod delete H2 CH3 H3 . .
+ACYmod change O C CH3 116.816 3.00
+ACYmod change OXT C CH3 116.816 3.00
+ACYmod change C CH3 H1 108.814 1.50
+ACYmod change C CH3 H2 108.814 1.50
+ACYmod change H1 CH3 H2 108.190 3.00
+
+data_mod_IVAm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+IVAm1 delete OXT . O OC -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+IVAm1 delete C OXT single . . . .
+IVAm1 change CA C single 1.516 0.0100 1.516 0.0100
+IVAm1 change C O double 1.234 0.0183 1.234 0.0183
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+IVAm1 delete CA C OXT . .
+IVAm1 delete O C OXT . .
+IVAm1 change CB CA C 112.394 1.82
+IVAm1 change C CA HA1 109.131 1.50
+IVAm1 change C CA HA2 109.131 1.50
+IVAm1 change CA C O 122.046 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+IVAm1 delete plan-1 C 0.020
+IVAm1 delete plan-1 CA 0.020
+IVAm1 delete plan-1 O 0.020
+IVAm1 delete plan-1 OXT 0.020
+
+data_mod_BOCm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+BOCm1 delete O3 . O OH1 0
+BOCm1 delete H3 . H H 0
+BOCm1 change O2 . O O 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+BOCm1 delete C O3 single . . . .
+BOCm1 delete O3 H3 single . . . .
+BOCm1 change O1 C double 1.217 0.0100 1.217 0.0100
+BOCm1 change C O2 single 1.341 0.0114 1.341 0.0114
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+BOCm1 delete O1 C O3 . .
+BOCm1 delete O2 C O3 . .
+BOCm1 delete C O3 H3 . .
+BOCm1 change O1 C O2 125.546 1.50
+BOCm1 change C O2 CT 120.869 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+BOCm1 delete O1 C O3 H3 . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+BOCm1 delete plan-1 C 0.020
+BOCm1 delete plan-1 O1 0.020
+BOCm1 delete plan-1 O2 0.020
+BOCm1 delete plan-1 O3 0.020
+
+data_mod_NMEm1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+NMEm1 delete HN2 . H H 0
+NMEm1 change N . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+NMEm1 delete N HN2 single . . . .
+NMEm1 change N C single 1.451 0.0100 1.451 0.0100
+NMEm1 change N HN1 single 0.871 0.0200 1.016 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+NMEm1 delete C N HN2 . .
+NMEm1 delete HN1 N HN2 . .
+NMEm1 change C N HN1 118.830 3.00
+NMEm1 change N C H1 109.501 1.50
+NMEm1 change N C H2 109.501 1.50
+NMEm1 change N C H3 109.501 1.50
+
+data_mod_SNNmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+SNNmod1 delete HN . H H 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+SNNmod1 delete N1 HN single . . . .
+SNNmod1 change N1 C single 1.383 0.0109 1.383 0.0109
+SNNmod1 change N1 C5 single 1.382 0.0100 1.382 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+SNNmod1 delete C N1 HN . .
+SNNmod1 delete C5 N1 HN . .
+SNNmod1 change C N1 C5 112.532 1.50
+SNNmod1 change N1 C CA 108.820 1.50
+SNNmod1 change N1 C O 125.193 1.71
+SNNmod1 change N1 C5 C4 108.523 1.50
+SNNmod1 change N1 C5 O5 124.084 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+SNNmod1 delete plan-1 C 0.020
+SNNmod1 delete plan-1 C5 0.020
+SNNmod1 delete plan-1 HN 0.020
+SNNmod1 delete plan-1 N1 0.020
+
+data_mod_SNNmod
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+SNNmod delete H . H H 0
+SNNmod delete H2 . H H 0
+SNNmod change N1 . N NR15 0
+SNNmod change N . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+SNNmod delete N H single . . . .
+SNNmod delete N H2 single . . . .
+SNNmod change CA N single 1.447 0.0100 1.447 0.0100
+SNNmod change N H33 single 0.875 0.0126 1.016 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+SNNmod delete CA N H . .
+SNNmod delete CA N H2 . .
+SNNmod delete H N H2 . .
+SNNmod delete H N H33 . .
+SNNmod delete H2 N H33 . .
+SNNmod change C CA N 111.533 1.50
+SNNmod change N CA C4 114.845 1.50
+SNNmod change N CA HA 108.330 1.50
+SNNmod change CA N H33 119.750 2.24
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+SNNmod delete C CA N H . .
+
+data_mod_TPNmodC
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+TPNmodC change O . . O 0.000
+TPNmodC delete OXT . . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+TPNmodC delete C OXT deloc . . . .
+TPNmodC change C O double 1.220 0.020 1.220 0.020
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+TPNmodC delete OXT C O . .
+TPNmodC delete "C5'" C OXT . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+TPNmodC delete plan-3 "C5'" .
+TPNmodC delete plan-3 C .
+TPNmodC delete plan-3 OXT .
+TPNmodC delete plan-3 O .
+
+data_mod_TPNmodN
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+TPNmodN change N . . NH1 0.000
+TPNmodN delete H3 . . . .
+TPNmodN delete H2 . . . .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+TPNmodN change "C2'" N . 1.450 0.020 1.450 0.020
+TPNmodN delete N H3 single . . . .
+TPNmodN delete N H2 single . . . .
+TPNmodN change N H . 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+TPNmodN change "C2'" N H 118.500 3.000
+TPNmodN delete "C2'" N H2 . .
+TPNmodN delete "C2'" N H3 . .
+TPNmodN delete H2 N H . .
+TPNmodN delete H3 N H . .
+TPNmodN delete H3 N H2 . .
+
+data_mod_ORN-NE
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+ORN-NE delete HE2 . H H 0
+ORN-NE change NE . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+ORN-NE delete NE HE2 single . . . .
+ORN-NE change CG CD single 1.521 0.0200 1.521 0.0200
+ORN-NE change CD HD3 single 0.979 0.0175 1.089 0.0100
+ORN-NE change CD HD2 single 0.979 0.0175 1.089 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+ORN-NE delete CD NE HE2 . .
+ORN-NE delete HE1 NE HE2 . .
+ORN-NE change CB CG CD 112.025 3.00
+ORN-NE change CG CD NE 112.594 1.78
+ORN-NE change CG CD HD3 109.172 2.35
+ORN-NE change CG CD HD2 109.172 2.35
+ORN-NE change CD NE HE1 118.122 3.00
+
+data_mod_HECmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+HECmod1 change CAC . . CH1 .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+HECmod1 change C3C CAC single 1.524 0.020 1.524 0.020
+HECmod1 change CAC HAC . 0.975 0.010 1.082 0.013
+HECmod1 change CAC CBC . 1.524 0.020 1.524 0.020
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+HECmod1 change C3C CAC HAC 108.340 3.000
+HECmod1 change C3C CAC CBC 111.000 3.000
+HECmod1 change HAC CAC CBC 108.340 3.000
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+HECmod1 delete plan-8 CBC .
+HECmod1 delete plan-8 HAC .
+
+data_mod_HECmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_partial_charge
+HECmod2 change CAB . . CH1 .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+HECmod2 change C3B CAB single 1.524 0.020 1.524 0.020
+HECmod2 change CAB HAB . 0.975 0.010 1.082 0.013
+HECmod2 change CAB CBB . 1.524 0.020 1.524 0.020
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+HECmod2 change C3B CAB HAB 108.340 3.000
+HECmod2 change C3B CAB CBB 111.000 3.000
+HECmod2 change HAB CAB CBB 108.340 3.000
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+HECmod2 delete plan-7 CBB .
+HECmod2 delete plan-7 HAB .
+
+data_mod_02Jmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+02Jmod1 delete OXT . O OC -1
+02Jmod1 change O1 . O O 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+02Jmod1 delete C OXT single . . . .
+02Jmod1 change CA C single 1.485 0.0100 1.485 0.0100
+02Jmod1 change C O double 1.232 0.0107 1.232 0.0107
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+02Jmod1 delete CA C OXT . .
+02Jmod1 delete O C OXT . .
+02Jmod1 change CA C O 121.966 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+02Jmod1 change C5 C4 CA C const_sp2_sp2_2 180.000 0.0 2
+02Jmod1 change C CA N O1 const_sp2_sp2_6 180.000 0.0 2
+02Jmod1 change C4 CA C O sp2_sp2_15 0.000 5.0 2
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+02Jmod1 delete plan-2 CA 0.020
+02Jmod1 delete plan-2 C 0.020
+02Jmod1 delete plan-2 O 0.020
+02Jmod1 delete plan-2 OXT 0.020
+
+data_mod_BMEmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+BMEmod1 delete HS2 . H HSH1 0
+BMEmod1 change S2 . S S2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+BMEmod1 delete S2 HS2 single . . . .
+BMEmod1 change C2 S2 single 1.816 0.0107 1.816 0.0107
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+BMEmod1 delete C2 S2 HS2 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+BMEmod1 delete C1 C2 S2 HS2 . .
+
+data_mod_CR8mod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+CR8mod1 delete OXT . O OC -1
+CR8mod1 change N3 . N NR5 0
+CR8mod1 change N22 . N NR15 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+CR8mod1 delete C3 OXT single . . . .
+CR8mod1 change C3 O3 double 1.229 0.0100 1.229 0.0100
+CR8mod1 change CA3 HA31 single 0.979 0.0109 1.089 0.0100
+CR8mod1 change CA3 HA32 single 0.979 0.0109 1.089 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+CR8mod1 delete CA3 C3 OXT . .
+CR8mod1 delete O3 C3 OXT . .
+CR8mod1 change C2 N3 CA3 123.659 1.50
+CR8mod1 change C1 N3 CA3 129.208 1.50
+CR8mod1 change CA3 C3 O3 120.652 3.00
+CR8mod1 change N3 CA3 C3 111.504 3.00
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+CR8mod1 delete plan-10 C3 0.020
+CR8mod1 delete plan-10 CA3 0.020
+CR8mod1 delete plan-10 O3 0.020
+CR8mod1 delete plan-10 OXT 0.020
+
+data_mod_CROmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+CROmod1 delete OXT . O OC -1
+CROmod1 change N3 . N NT 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+CROmod1 delete C3 OXT single . . . .
+CROmod1 change CA3 C3 single 1.525 0.0112 1.525 0.0112
+CROmod1 change C3 O3 double 1.225 0.0118 1.225 0.0118
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+CROmod1 delete CA3 C3 OXT . .
+CROmod1 delete OXT C3 O3 . .
+CROmod1 change CA3 C3 O3 121.784 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+CROmod1 delete OXT C3 CA3 N3 . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+CROmod1 delete plan-6 C3 0.020
+CROmod1 delete plan-6 CA3 0.020
+CROmod1 delete plan-6 O3 0.020
+CROmod1 delete plan-6 OXT 0.020
+CROmod1 delete plan-7 CA2 0.020
+CROmod1 delete plan-7 CB2 0.020
+CROmod1 delete plan-7 CG2 0.020
+CROmod1 delete plan-7 HB2 0.020
+CROmod1 delete plan-1 CB2 0.020
+CROmod1 delete plan-1 CD1 0.020
+CROmod1 delete plan-1 CD2 0.020
+CROmod1 delete plan-1 CE1 0.020
+CROmod1 delete plan-1 CE2 0.020
+CROmod1 delete plan-1 CG2 0.020
+CROmod1 delete plan-1 CZ 0.020
+CROmod1 delete plan-1 HD1 0.020
+CROmod1 delete plan-1 HD2 0.020
+CROmod1 delete plan-1 HE1 0.020
+CROmod1 delete plan-1 HE2 0.020
+CROmod1 delete plan-1 OH 0.020
+
+data_mod_CYCmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+CYCmod1 delete HAC2 . H H 0
+CYCmod1 change NB . N NR15 0
+CYCmod1 change NC . N NR15 0
+CYCmod1 change CAC . C CH1 0
+CYCmod1 change ND . N NR15 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+CYCmod1 delete CAC HAC2 single . . . .
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+CYCmod1 delete C3C CAC HAC2 . .
+CYCmod1 delete CBC CAC HAC2 . .
+CYCmod1 delete HAC1 CAC HAC2 . .
+CYCmod1 change C1C C2C C3C 103.889 3.00
+CYCmod1 change C3C C2C CMC 114.019 3.00
+CYCmod1 change C3C C2C H2C 109.899 3.00
+CYCmod1 change C2C C3C C4C 103.889 3.00
+CYCmod1 change C2C C3C H3C 109.899 3.00
+CYCmod1 change CAC C3C H3C 108.714 2.67
+CYCmod1 change NC C4C C3C 108.238 2.80
+CYCmod1 change C3C CAC CBC 112.891 3.00
+CYCmod1 change CBC CAC HAC1 108.988 3.00
+CYCmod1 change CAC CBC HBC1 109.511 1.50
+CYCmod1 change CAC CBC HBC2 109.511 1.50
+CYCmod1 change CAC CBC HBC3 109.511 1.50
+
+data_mod_FADmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+FADmod1 delete HM83 . H H 0
+FADmod1 change C8M . C CH2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+FADmod1 delete C8M HM83 single . . . .
+FADmod1 change C7 C8 single 1.401 0.0100 1.401 0.0100
+FADmod1 change C8 C8M single 1.516 0.0100 1.516 0.0100
+FADmod1 change C8 C9 double 1.377 0.0162 1.377 0.0162
+FADmod1 change C8M HM81 single 0.982 0.0200 1.089 0.0100
+FADmod1 change C8M HM82 single 0.982 0.0200 1.089 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+FADmod1 delete C8 C8M HM83 . .
+FADmod1 delete HM81 C8M HM83 . .
+FADmod1 delete HM82 C8M HM83 . .
+FADmod1 change C7 C8 C8M 120.426 2.23
+FADmod1 change C8M C8 C9 120.074 3.00
+
+data_mod_PEBmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+PEBmod1 delete HAA2 . H H 0
+PEBmod1 change NC . N NR15 0
+PEBmod1 change ND . N NR15 0
+PEBmod1 change NA . N NR15 0
+PEBmod1 change CAA . C CH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+PEBmod1 delete CAA HAA2 single . . . .
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+PEBmod1 delete C3A CAA HAA2 . .
+PEBmod1 delete CBA CAA HAA2 . .
+PEBmod1 delete HAA1 CAA HAA2 . .
+PEBmod1 change C1A C2A C3A 103.889 3.00
+PEBmod1 change C3A C2A CMA 114.019 3.00
+PEBmod1 change C3A C2A H2A1 109.899 3.00
+PEBmod1 change C2A C3A C4A 103.889 3.00
+PEBmod1 change C2A C3A H3A1 109.899 3.00
+PEBmod1 change CAA C3A H3A1 108.714 2.67
+PEBmod1 change NA C4A C3A 109.147 2.80
+PEBmod1 change C3A C4A CHA 124.214 1.50
+PEBmod1 change CAA CBA HBA1 109.511 1.50
+PEBmod1 change CAA CBA HBA2 109.511 1.50
+PEBmod1 change CAA CBA HBA3 109.511 1.50
+PEBmod1 change C3A CAA CBA 112.891 3.00
+PEBmod1 change CBA CAA HAA1 108.988 3.00
+
+data_mod_HISmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+HISmod1 delete HD1 . H H 0
+HISmod1 change ND1 . N NR5 1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+HISmod1 delete ND1 HD1 single . . . .
+HISmod1 change CB CG single 1.491 0.0100 1.491 0.0100
+HISmod1 change CG ND1 single 1.352 0.0200 1.352 0.0200
+HISmod1 change CG CD2 double 1.357 0.0100 1.357 0.0100
+HISmod1 change ND1 CE1 double 1.351 0.0200 1.351 0.0200
+HISmod1 change CE1 HE1 single 0.939 0.0134 1.082 0.0130
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+HISmod1 delete CG ND1 HD1 . .
+HISmod1 delete CE1 ND1 HD1 . .
+HISmod1 change CB CG ND1 123.044 1.50
+HISmod1 change CG CD2 HD2 126.231 1.50
+HISmod1 change ND1 CE1 HE1 125.433 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+HISmod1 delete plan-1 CB 0.020
+HISmod1 delete plan-1 CD2 0.020
+HISmod1 delete plan-1 CE1 0.020
+HISmod1 delete plan-1 CG 0.020
+HISmod1 delete plan-1 HD1 0.020
+HISmod1 delete plan-1 HD2 0.020
+HISmod1 delete plan-1 HE1 0.020
+HISmod1 delete plan-1 HE2 0.020
+HISmod1 delete plan-1 ND1 0.020
+HISmod1 delete plan-1 NE2 0.020
+
+data_mod_FADmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+FADmod2 delete HM83 . H H 0
+FADmod2 change C8M . C CH2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+FADmod2 delete C8M HM83 single . . . .
+FADmod2 change C7 C8 single 1.398 0.0119 1.398 0.0119
+FADmod2 change C8 C8M single 1.514 0.0100 1.514 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+FADmod2 delete C8 C8M HM83 . .
+FADmod2 delete HM81 C8M HM83 . .
+FADmod2 delete HM82 C8M HM83 . .
+FADmod2 change C7 C8 C8M 120.918 3.00
+FADmod2 change C8M C8 C9 119.582 3.00
+
+data_mod_HISmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+HISmod2 delete HE2 . H H 0
+HISmod2 change NE2 . N NR5 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+HISmod2 delete NE2 HE2 single . . . .
+HISmod2 change CG CD2 double 1.366 0.0178 1.366 0.0178
+HISmod2 change ND1 CE1 double 1.344 0.0200 1.344 0.0200
+HISmod2 change CE1 NE2 single 1.322 0.0100 1.322 0.0100
+HISmod2 change CD2 HD2 single 0.949 0.0120 1.082 0.0130
+HISmod2 change CE1 HE1 single 0.939 0.0134 1.082 0.0130
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+HISmod2 delete CD2 NE2 HE2 . .
+HISmod2 delete CE1 NE2 HE2 . .
+HISmod2 change NE2 CD2 HD2 125.717 1.62
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+HISmod2 delete plan-1 CB 0.020
+HISmod2 delete plan-1 CD2 0.020
+HISmod2 delete plan-1 CE1 0.020
+HISmod2 delete plan-1 CG 0.020
+HISmod2 delete plan-1 HD1 0.020
+HISmod2 delete plan-1 HD2 0.020
+HISmod2 delete plan-1 HE1 0.020
+HISmod2 delete plan-1 HE2 0.020
+HISmod2 delete plan-1 ND1 0.020
+HISmod2 delete plan-1 NE2 0.020
+
+data_mod_FADmod3
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+FADmod3 delete HM83 . H H 0
+FADmod3 change C8M . C CH2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+FADmod3 delete C8M HM83 single . . . .
+FADmod3 change C7 C8 single 1.398 0.0119 1.398 0.0119
+FADmod3 change C8 C8M single 1.514 0.0100 1.514 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+FADmod3 delete C8 C8M HM83 . .
+FADmod3 delete HM81 C8M HM83 . .
+FADmod3 delete HM82 C8M HM83 . .
+FADmod3 change C7 C8 C8M 120.918 3.00
+FADmod3 change C8M C8 C9 119.582 3.00
+
+data_mod_GTPmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+GTPmod1 delete "HO3'" . H H 0
+GTPmod1 change "O3'" . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+GTPmod1 delete "O3'" "HO3'" single . . . .
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+GTPmod1 delete "C3'" "O3'" "HO3'" . .
+GTPmod1 change "C5'" "C4'" "C3'" 114.817 2.32
+GTPmod1 change "C3'" "C4'" "H4'" 109.150 1.50
+GTPmod1 change "C2'" "C3'" "H3'" 110.368 2.92
+GTPmod1 change "C3'" "C2'" "H2'" 110.368 2.92
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+GTPmod1 delete "C4'" "C3'" "O3'" "HO3'" . . . 0
+
+data_mod_GYCmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+GYCmod1 delete OXT . O OC -1
+GYCmod1 change N3 . N NR5 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+GYCmod1 delete C3 OXT single . . . .
+GYCmod1 change CA3 C3 single 1.525 0.0112 1.525 0.0112
+GYCmod1 change C3 O3 double 1.225 0.0118 1.225 0.0118
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+GYCmod1 delete CA3 C3 OXT . .
+GYCmod1 delete O3 C3 OXT . .
+GYCmod1 change CA3 C3 O3 121.784 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+GYCmod1 delete plan-6 C3 0.020
+GYCmod1 delete plan-6 CA3 0.020
+GYCmod1 delete plan-6 O3 0.020
+GYCmod1 delete plan-6 OXT 0.020
+GYCmod1 delete plan-5 CA2 0.020
+GYCmod1 delete plan-5 CB2 0.020
+GYCmod1 delete plan-5 CG2 0.020
+GYCmod1 delete plan-5 HB2 0.020
+GYCmod1 delete plan-1 CB2 0.020
+GYCmod1 delete plan-1 CD1 0.020
+GYCmod1 delete plan-1 CD2 0.020
+GYCmod1 delete plan-1 CE1 0.020
+GYCmod1 delete plan-1 CE2 0.020
+GYCmod1 delete plan-1 CG2 0.020
+GYCmod1 delete plan-1 CZ 0.020
+GYCmod1 delete plan-1 HD1 0.020
+GYCmod1 delete plan-1 HD2 0.020
+GYCmod1 delete plan-1 HE1 0.020
+GYCmod1 delete plan-1 HE2 0.020
+GYCmod1 delete plan-1 OH 0.020
+
+data_mod_HEMmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+HEMmod2 change CAB . C CH1 0
+HEMmod2 change CBB . C CH3 0
+HEMmod2 add . H33 H H .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+HEMmod2 change C3B CAB single 1.505 0.0154 1.505 0.0154
+HEMmod2 change CAB CBB single 1.512 0.0105 1.512 0.0105
+HEMmod2 change CAB HAB single 0.975 0.010 1.082 0.013
+HEMmod2 add CBB H33 single 0.975 0.010 1.082 0.013
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+HEMmod2 change C3B CAB CBB 111.339 2.21
+HEMmod2 change C3B CAB HAB 108.716 1.64
+HEMmod2 change CBB CAB HAB 108.681 1.50
+HEMmod2 change CAB CBB HBBA 109.47 3.000
+HEMmod2 change CAB CBB HBB 109.47 3.000
+HEMmod2 change HBBA CBB HBB 109.47 3.000
+HEMmod2 add CAB CBB H33 109.528 1.50
+HEMmod2 add HBB CBB H33 109.399 1.50
+HEMmod2 add HBBA CBB H33 109.399 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.id
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+HEMmod2 change sp2_sp3_new2 C2B C3B CAB CBB -90.000 10.00 6
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+HEMmod2 delete plan-8 CAB 0.020
+HEMmod2 delete plan-8 C3B 0.020
+HEMmod2 delete plan-8 CBB 0.020
+HEMmod2 delete plan-8 HAB 0.020
+HEMmod2 delete plan-8 HBB 0.020
+HEMmod2 delete plan-8 HBBA 0.020
+
+data_mod_HEMmod3
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+HEMmod3 change CAC . C CH1 0
+HEMmod3 change CBC . C CH3 0
+HEMmod3 add . H34 H H .
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+HEMmod3 change C3C CAC single 1.505 0.0154 1.505 0.0154
+HEMmod3 change CAC CBC single 1.512 0.0105 1.512 0.0105
+HEMmod3 change CAC HAC single 0.975 0.010 1.082 0.013
+HEMmod3 add CBC H34 single 0.975 0.010 1.082 0.013
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+HEMmod3 change C3C CAC CBC 111.339 2.21
+HEMmod3 change C3C CAC HAC 108.716 1.64
+HEMmod3 change CBC CAC HAC 108.681 1.50
+HEMmod3 change CAC CBC HBCA 109.47 3.000
+HEMmod3 change CAC CBC HBC 109.47 3.000
+HEMmod3 change HBCA CBC HBC 109.47 3.000
+HEMmod3 add CAC CBC H34 109.528 1.50
+HEMmod3 add HBC CBC H34 109.399 1.50
+HEMmod3 add HBCA CBC H34 109.399 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.id
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+HEMmod3 change sp2_sp3_new3 C2C C3C CAC CBC -90.000 10.00 6
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+HEMmod3 delete plan-10 CAC 0.020
+HEMmod3 delete plan-10 C3C 0.020
+HEMmod3 delete plan-10 CBC 0.020
+HEMmod3 delete plan-10 HAC 0.020
+HEMmod3 delete plan-10 HBC 0.020
+HEMmod3 delete plan-10 HBCA 0.020
+
+data_mod_TYRmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+TYRmod1 delete HB3 . H H 0
+TYRmod1 change CB . C CH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+TYRmod1 delete CB HB3 single . . . .
+TYRmod1 change CA C single 1.533 0.0111 1.533 0.0111
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+TYRmod1 delete CA CB HB3 . .
+TYRmod1 delete CG CB HB3 . .
+TYRmod1 delete HB3 CB HB2 . .
+TYRmod1 change N CA CB 113.399 3.00
+TYRmod1 change CA C O 117.156 1.94
+TYRmod1 change CA C OXT 117.156 1.94
+TYRmod1 change CA CB CG 113.308 3.00
+TYRmod1 change CA CB HB2 106.713 1.50
+TYRmod1 change CG CB HB2 107.067 3.00
+TYRmod1 change CB CG CD1 120.731 3.00
+TYRmod1 change CB CG CD2 120.731 3.00
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+TYRmod1 change N CA CB CG sp3_sp3_28 180.000 10.0 3
+TYRmod1 change CD1 CG CB CA sp2_sp3_19 150.000 10.0 6
+
+data_mod_HISmod3
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+HISmod3 delete HE2 . H H 0
+HISmod3 change NE2 . N NR5 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+HISmod3 delete NE2 HE2 single . . . .
+HISmod3 change CG CD2 double 1.364 0.0129 1.364 0.0129
+HISmod3 change ND1 CE1 double 1.351 0.0200 1.351 0.0200
+HISmod3 change CD2 NE2 single 1.376 0.0100 1.376 0.0100
+HISmod3 change CE1 NE2 single 1.338 0.0162 1.338 0.0162
+HISmod3 change CD2 HD2 single 0.947 0.0141 1.082 0.0130
+HISmod3 change CE1 HE1 single 0.928 0.0133 1.082 0.0130
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+HISmod3 delete CD2 NE2 HE2 . .
+HISmod3 delete CE1 NE2 HE2 . .
+HISmod3 change CG ND1 CE1 108.905 3.00
+HISmod3 change CG CD2 NE2 108.374 2.83
+HISmod3 change CG CD2 HD2 126.805 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+HISmod3 delete plan-1 CB 0.020
+HISmod3 delete plan-1 CD2 0.020
+HISmod3 delete plan-1 CE1 0.020
+HISmod3 delete plan-1 CG 0.020
+HISmod3 delete plan-1 HD1 0.020
+HISmod3 delete plan-1 HD2 0.020
+HISmod3 delete plan-1 HE1 0.020
+HISmod3 delete plan-1 HE2 0.020
+HISmod3 delete plan-1 ND1 0.020
+HISmod3 delete plan-1 NE2 0.020
+
+data_mod_TYRmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+TYRmod2 delete HE2 . H H 0
+TYRmod2 change CE2 . C CR6 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+TYRmod2 delete CE2 HE2 single . . . .
+TYRmod2 change CG CD2 single 1.374 0.0100 1.374 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+TYRmod2 delete CD2 CE2 HE2 . .
+TYRmod2 delete CZ CE2 HE2 . .
+TYRmod2 change CB CG CD2 121.348 2.28
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+TYRmod2 delete plan-1 CB 0.020
+TYRmod2 delete plan-1 CD1 0.020
+TYRmod2 delete plan-1 CD2 0.020
+TYRmod2 delete plan-1 CE1 0.020
+TYRmod2 delete plan-1 CE2 0.020
+TYRmod2 delete plan-1 CG 0.020
+TYRmod2 delete plan-1 CZ 0.020
+TYRmod2 delete plan-1 HD1 0.020
+TYRmod2 delete plan-1 HD2 0.020
+TYRmod2 delete plan-1 HE1 0.020
+TYRmod2 delete plan-1 HE2 0.020
+TYRmod2 delete plan-1 OH 0.020
+
+data_mod_IASmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+IASmod1 delete OD2 . O OC -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+IASmod1 delete CG OD2 single . . . .
+IASmod1 change CB CG single 1.508 0.0116 1.508 0.0116
+IASmod1 change CG OD1 double 1.229 0.0102 1.229 0.0102
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+IASmod1 delete CB CG OD2 . .
+IASmod1 delete OD1 CG OD2 . .
+IASmod1 change CB CG OD1 121.290 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+IASmod1 delete plan-2 CB 0.020
+IASmod1 delete plan-2 CG 0.020
+IASmod1 delete plan-2 OD1 0.020
+IASmod1 delete plan-2 OD2 0.020
+
+data_mod_LYSmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+LYSmod1 delete HZ2 . H H 0
+LYSmod1 delete HZ3 . H H 0
+LYSmod1 change NZ . N NT1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+LYSmod1 delete NZ HZ2 single . . . .
+LYSmod1 delete NZ HZ3 single . . . .
+LYSmod1 change CE NZ single 1.468 0.0134 1.468 0.0134
+LYSmod1 change NZ HZ1 single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+LYSmod1 delete CE NZ HZ2 . .
+LYSmod1 delete CE NZ HZ3 . .
+LYSmod1 delete HZ1 NZ HZ2 . .
+LYSmod1 delete HZ1 NZ HZ3 . .
+LYSmod1 delete HZ2 NZ HZ3 . .
+LYSmod1 change CE NZ HZ1 111.861 3.00
+
+data_mod_CYSmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+CYSmod2 delete HG . H HSH1 0
+CYSmod2 change SG . S S2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+CYSmod2 delete SG HG single . . . .
+CYSmod2 change CB SG single 1.805 0.0100 1.805 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+CYSmod2 delete CB SG HG . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+CYSmod2 delete CA CB SG HG . .
+
+data_mod_LYSmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+LYSmod2 delete HZ1 . H H 0
+LYSmod2 delete HZ2 . H H 0
+LYSmod2 delete HZ3 . H H 0
+LYSmod2 change NZ . N N 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+LYSmod2 delete NZ HZ1 single . . . .
+LYSmod2 delete NZ HZ2 single . . . .
+LYSmod2 delete NZ HZ3 single . . . .
+LYSmod2 change CE NZ single 1.480 0.0168 1.480 0.0168
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+LYSmod2 delete CE NZ HZ1 . .
+LYSmod2 delete CE NZ HZ2 . .
+LYSmod2 delete CE NZ HZ3 . .
+LYSmod2 delete HZ1 NZ HZ2 . .
+LYSmod2 delete HZ1 NZ HZ3 . .
+LYSmod2 delete HZ2 NZ HZ3 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+LYSmod2 delete CD CE NZ HZ3 . .
+
+data_mod_RETmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+RETmod1 delete O1 . O O 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+RETmod1 delete C15 O1 double . . . .
+RETmod1 change C14 C15 single 1.475 0.0179 1.475 0.0179
+RETmod1 change C15 H15 single 0.945 0.0154 1.082 0.0130
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+RETmod1 delete C14 C15 O1 . .
+RETmod1 delete O1 C15 H15 . .
+RETmod1 change C14 C15 H15 119.875 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+RETmod1 delete C13 C14 C15 O1 . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+RETmod1 delete plan-11 C14 0.020
+RETmod1 delete plan-11 C15 0.020
+RETmod1 delete plan-11 H15 0.020
+RETmod1 delete plan-11 O1 0.020
+
+data_mod_LYSmod3
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+LYSmod3 delete HZ2 . H H 0
+LYSmod3 delete HZ3 . H H 0
+LYSmod3 change NZ . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+LYSmod3 delete NZ HZ2 single . . . .
+LYSmod3 delete NZ HZ3 single . . . .
+LYSmod3 change CE NZ single 1.456 0.0109 1.456 0.0109
+LYSmod3 change NZ HZ1 single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+LYSmod3 delete CE NZ HZ2 . .
+LYSmod3 delete CE NZ HZ3 . .
+LYSmod3 delete HZ1 NZ HZ2 . .
+LYSmod3 delete HZ1 NZ HZ3 . .
+LYSmod3 delete HZ2 NZ HZ3 . .
+LYSmod3 change CE NZ HZ1 118.241 1.90
+
+data_mod_ASNmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+ASNmod1 delete ND2 . N NH2 0
+ASNmod1 delete HD21 . H H 0
+ASNmod1 delete HD22 . H H 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+ASNmod1 delete CG ND2 single . . . .
+ASNmod1 delete ND2 HD21 single . . . .
+ASNmod1 delete ND2 HD22 single . . . .
+ASNmod1 change CB CG single 1.508 0.0116 1.508 0.0116
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+ASNmod1 delete CB CG ND2 . .
+ASNmod1 delete OD1 CG ND2 . .
+ASNmod1 delete CG ND2 HD21 . .
+ASNmod1 delete CG ND2 HD22 . .
+ASNmod1 delete HD21 ND2 HD22 . .
+ASNmod1 change CB CG OD1 121.400 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+ASNmod1 delete CB CG ND2 HD21 . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+ASNmod1 delete plan-2 CB 0.020
+ASNmod1 delete plan-2 CG 0.020
+ASNmod1 delete plan-2 ND2 0.020
+ASNmod1 delete plan-2 OD1 0.020
+ASNmod1 delete plan-3 CG 0.020
+ASNmod1 delete plan-3 HD21 0.020
+ASNmod1 delete plan-3 HD22 0.020
+ASNmod1 delete plan-3 ND2 0.020
+
+data_mod_MDOmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+MDOmod1 delete OXT . O OC -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+MDOmod1 delete C3 OXT single . . . .
+MDOmod1 change CA3 C3 single 1.525 0.0112 1.525 0.0112
+MDOmod1 change C3 O3 double 1.225 0.0118 1.225 0.0118
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+MDOmod1 delete CA3 C3 OXT . .
+MDOmod1 delete O3 C3 OXT . .
+MDOmod1 change CA3 C3 O3 121.784 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+MDOmod1 delete plan-6 C3 0.020
+MDOmod1 delete plan-6 CA3 0.020
+MDOmod1 delete plan-6 O3 0.020
+MDOmod1 delete plan-6 OXT 0.020
+MDOmod1 delete plan-4 CA2 0.020
+MDOmod1 delete plan-4 CB2 0.020
+MDOmod1 delete plan-4 HB21 0.020
+MDOmod1 delete plan-4 HB22 0.020
+MDOmod1 delete plan-4 CA2 0.020
+MDOmod1 delete plan-4 CB2 0.020
+MDOmod1 delete plan-4 HB21 0.020
+MDOmod1 delete plan-4 HB22 0.020
+
+data_mod_METmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+METmod1 change SD . S S3 1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+METmod1 change CG SD single 1.808 0.0100 1.808 0.0100
+METmod1 change CE HE3 single 0.967 0.0100 1.089 0.0100
+METmod1 change CE HE2 single 0.967 0.0100 1.089 0.0100
+METmod1 change CE HE1 single 0.967 0.0100 1.089 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+METmod1 change CA CB CG 114.058 2.21
+METmod1 change CG CB HB3 108.377 2.40
+METmod1 change CG CB HB2 108.377 2.40
+METmod1 change CB CG SD 110.122 1.50
+METmod1 change CB CG HG3 108.661 3.00
+METmod1 change CB CG HG2 108.661 3.00
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+METmod1 change CA CB CG SD sp3_sp3_19 180.000 10.0 3
+METmod1 change CB CG SD CE sp3_sp3_28 180.000 10.0 3
+
+data_mod_TYRmod3
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+TYRmod3 delete HE1 . H H 0
+TYRmod3 change CE1 . C CR6 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+TYRmod3 delete CE1 HE1 single . . . .
+TYRmod3 change CE1 CZ double 1.395 0.0152 1.395 0.0152
+TYRmod3 change CD1 HD1 single 0.940 0.0104 1.082 0.0130
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+TYRmod3 delete CD1 CE1 HE1 . .
+TYRmod3 delete CZ CE1 HE1 . .
+TYRmod3 change CB CG CD1 121.186 2.28
+TYRmod3 change CG CD1 HD1 119.873 2.79
+TYRmod3 change CD1 CE1 CZ 119.634 2.58
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+TYRmod3 change CB CG CD1 CE1 const_sp2_sp2_3 180.000 0.0 2
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+TYRmod3 delete plan-1 CB 0.020
+TYRmod3 delete plan-1 CD1 0.020
+TYRmod3 delete plan-1 CD2 0.020
+TYRmod3 delete plan-1 CE1 0.020
+TYRmod3 delete plan-1 CE2 0.020
+TYRmod3 delete plan-1 CG 0.020
+TYRmod3 delete plan-1 CZ 0.020
+TYRmod3 delete plan-1 HD1 0.020
+TYRmod3 delete plan-1 HD2 0.020
+TYRmod3 delete plan-1 HE1 0.020
+TYRmod3 delete plan-1 HE2 0.020
+TYRmod3 delete plan-1 OH 0.020
+
+data_mod_NRQmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+NRQmod1 delete OXT . O OC -1
+NRQmod1 change N3 . N NT 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+NRQmod1 delete C3 OXT single . . . .
+NRQmod1 change C3 O3 double 1.225 0.0118 1.225 0.0118
+NRQmod1 change CA3 C3 single 1.525 0.0112 1.525 0.0112
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+NRQmod1 delete OXT C3 O3 . .
+NRQmod1 delete OXT C3 CA3 . .
+NRQmod1 change O3 C3 CA3 121.784 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+NRQmod1 delete OXT C3 CA3 N3 . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+NRQmod1 delete plan-8 C3 0.020
+NRQmod1 delete plan-8 CA3 0.020
+NRQmod1 delete plan-8 O3 0.020
+NRQmod1 delete plan-8 OXT 0.020
+NRQmod1 delete plan-4 CA2 0.020
+NRQmod1 delete plan-4 CB2 0.020
+NRQmod1 delete plan-4 CG2 0.020
+NRQmod1 delete plan-4 HB2 0.020
+NRQmod1 delete plan-1 CB2 0.020
+NRQmod1 delete plan-1 CD1 0.020
+NRQmod1 delete plan-1 CD2 0.020
+NRQmod1 delete plan-1 CE1 0.020
+NRQmod1 delete plan-1 CE2 0.020
+NRQmod1 delete plan-1 CG2 0.020
+NRQmod1 delete plan-1 CZ 0.020
+NRQmod1 delete plan-1 HD1 0.020
+NRQmod1 delete plan-1 HD2 0.020
+NRQmod1 delete plan-1 HE1 0.020
+NRQmod1 delete plan-1 HE2 0.020
+NRQmod1 delete plan-1 OH 0.020
+
+data_mod_PJEmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+PJEmod1 delete OXT . O OC -1
+PJEmod1 change N6 . N NR15 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+PJEmod1 delete C OXT single . . . .
+PJEmod1 change C O double 1.205 0.0123 1.205 0.0123
+PJEmod1 change C21 C single 1.476 0.0119 1.476 0.0119
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+PJEmod1 delete O C OXT . .
+PJEmod1 delete OXT C C21 . .
+PJEmod1 change O C C21 125.479 1.98
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+PJEmod1 change C20 C21 C O sp2_sp2_26 0.000 5.0 2
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+PJEmod1 delete plan-3 C21 0.020
+PJEmod1 delete plan-3 C 0.020
+PJEmod1 delete plan-3 OXT 0.020
+PJEmod1 delete plan-3 O 0.020
+
+data_mod_010mod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+010mod1 delete HO . H H 0
+010mod1 change O . O O 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+010mod1 delete O HO single . . . .
+010mod1 change C O single 1.453 0.0131 1.453 0.0131
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+010mod1 delete C O HO . .
+010mod1 change O C C6 109.553 3.00
+010mod1 change O C H 109.516 2.13
+010mod1 change O C HA 109.516 2.13
+010mod1 change H C HA 108.266 2.50
+010mod1 change C C6 C1 120.643 1.98
+010mod1 change C C6 C5 120.648 1.98
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+010mod1 delete C6 C O HO . . . 0
+
+data_mod_PJEmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+PJEmod2 change C20 . C CH1 0
+PJEmod2 change C21 . C CH2 0
+PJEmod2 change N6 . N NR15 0
+PJEmod2 add . H42 H H 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+PJEmod2 change C21 C single 1.518 0.0135 1.518 0.0135
+PJEmod2 change C20 C21 single 1.520 0.0124 1.520 0.0124
+PJEmod2 change CA C25 single 1.529 0.0196 1.529 0.0196
+PJEmod2 change CA C20 single 1.535 0.0109 1.535 0.0109
+PJEmod2 change CA N single 1.473 0.0145 1.473 0.0145
+PJEmod2 change CA HA single 0.986 0.0200 1.089 0.0100
+PJEmod2 change C20 H15 single 0.992 0.0200 1.089 0.0100
+PJEmod2 change C21 H4 single 0.980 0.0157 1.089 0.0100
+PJEmod2 add C21 H42 single 0.980 0.0157 1.089 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+PJEmod2 change C25 CA C20 110.837 3.00
+PJEmod2 change C25 CA N 110.727 3.00
+PJEmod2 change C25 CA HA 107.635 1.50
+PJEmod2 change C20 CA N 111.845 3.00
+PJEmod2 change C20 CA HA 106.866 1.50
+PJEmod2 change N CA HA 107.384 3.00
+PJEmod2 change C21 C20 CA 112.022 1.71
+PJEmod2 change C21 C20 H15 108.654 2.98
+PJEmod2 change CA C20 H15 107.195 1.50
+PJEmod2 change C C21 C20 113.275 2.16
+PJEmod2 change C C21 H4 108.531 1.50
+PJEmod2 change C20 C21 H4 108.891 1.50
+PJEmod2 change O C C21 118.194 3.00
+PJEmod2 change OXT C C21 118.194 3.00
+PJEmod2 change C26 C25 CA 112.811 3.00
+PJEmod2 change CA C25 H7 108.533 1.50
+PJEmod2 change CA C25 H8 108.533 1.50
+PJEmod2 change CA N H 110.021 3.00
+PJEmod2 change CA N H2 110.021 3.00
+PJEmod2 add C C21 H42 108.531 1.50
+PJEmod2 add C20 C21 H42 108.891 1.50
+PJEmod2 add H4 C21 H42 107.937 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+PJEmod2 change C25 CA C20 C21 sp3_sp3_46 180.000 10.0 3
+PJEmod2 change CA C20 C21 C sp3_sp3_28 180.000 10.0 3
+PJEmod2 change O C C21 C20 sp2_sp3_8 120.000 10.0 6
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+PJEmod2 delete plan-1 CA 0.020
+PJEmod2 delete plan-1 C20 0.020
+PJEmod2 delete plan-1 C21 0.020
+PJEmod2 delete plan-1 H15 0.020
+PJEmod2 delete plan-2 C20 0.020
+PJEmod2 delete plan-2 C21 0.020
+PJEmod2 delete plan-2 C 0.020
+PJEmod2 delete plan-2 H4 0.020
+
+data_mod_PJEmod3
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+PJEmod3 delete H2 . H H 0
+PJEmod3 change N . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+PJEmod3 delete N H2 single . . . .
+PJEmod3 change CA N single 1.453 0.0100 1.453 0.0100
+PJEmod3 change N H single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+PJEmod3 delete CA N H2 . .
+PJEmod3 delete H N H2 . .
+PJEmod3 change CA N H 119.019 1.92
+
+data_mod_LEUmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+LEUmod1 delete OXT . O OC -1
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+LEUmod1 delete C OXT single . . . .
+LEUmod1 change CA C single 1.527 0.0100 1.527 0.0100
+LEUmod1 change C O double 1.229 0.0102 1.229 0.0102
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+LEUmod1 delete CA C OXT . .
+LEUmod1 delete O C OXT . .
+LEUmod1 change CA C O 121.041 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+LEUmod1 delete plan-1 C 0.020
+LEUmod1 delete plan-1 CA 0.020
+LEUmod1 delete plan-1 O 0.020
+LEUmod1 delete plan-1 OXT 0.020
+
+data_mod_LYSmod4
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+LYSmod4 delete HZ1 . H H 0
+LYSmod4 delete HZ2 . H H 0
+LYSmod4 delete HZ3 . H H 0
+LYSmod4 change NZ . N N 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+LYSmod4 delete NZ HZ1 single . . . .
+LYSmod4 delete NZ HZ2 single . . . .
+LYSmod4 delete NZ HZ3 single . . . .
+LYSmod4 change CE NZ single 1.462 0.0100 1.462 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+LYSmod4 delete CE NZ HZ1 . .
+LYSmod4 delete CE NZ HZ2 . .
+LYSmod4 delete CE NZ HZ3 . .
+LYSmod4 delete HZ1 NZ HZ2 . .
+LYSmod4 delete HZ1 NZ HZ3 . .
+LYSmod4 delete HZ2 NZ HZ3 . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+LYSmod4 delete CD CE NZ HZ1 . .
+
+data_mod_PLPmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+PLPmod1 delete O4A . O O 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+PLPmod1 delete C4A O4A double . . . .
+PLPmod1 change C4 C4A single 1.459 0.0148 1.459 0.0148
+PLPmod1 change C4A H4A single 0.975 0.010 1.082 0.013
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+PLPmod1 delete C4 C4A O4A . .
+PLPmod1 delete O4A C4A H4A . .
+PLPmod1 change C4 C4A H4A 118.833 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+PLPmod1 delete C3 C4 C4A O4A . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+PLPmod1 delete plan-2 C4 0.020
+PLPmod1 delete plan-2 C4A 0.020
+PLPmod1 delete plan-2 H4A 0.020
+PLPmod1 delete plan-2 O4A 0.020
+PLPmod1 delete plan-1 C2 0.020
+PLPmod1 delete plan-1 C2A 0.020
+PLPmod1 delete plan-1 C3 0.020
+PLPmod1 delete plan-1 C4 0.020
+PLPmod1 delete plan-1 C4A 0.020
+PLPmod1 delete plan-1 C5 0.020
+PLPmod1 delete plan-1 C5A 0.020
+PLPmod1 delete plan-1 C6 0.020
+PLPmod1 delete plan-1 H6 0.020
+PLPmod1 delete plan-1 N1 0.020
+PLPmod1 delete plan-1 O3 0.020
+
+data_mod_TRPmod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+TRPmod1 delete HH2 . H H 0
+TRPmod1 change CH2 . C CR6 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+TRPmod1 delete CH2 HH2 single . . . .
+TRPmod1 change CE2 CZ2 single 1.395 0.0185 1.395 0.0185
+TRPmod1 change CE3 CZ3 double 1.379 0.0158 1.379 0.0158
+TRPmod1 change CZ2 CH2 double 1.391 0.0100 1.391 0.0100
+TRPmod1 change CZ3 CH2 single 1.412 0.0100 1.412 0.0100
+TRPmod1 change CZ2 HZ2 single 0.950 0.0100 1.082 0.0130
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+TRPmod1 delete CZ2 CH2 HH2 . .
+TRPmod1 delete CZ3 CH2 HH2 . .
+TRPmod1 change CE2 CZ2 CH2 119.258 1.50
+TRPmod1 change CZ2 CH2 CZ3 119.154 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+TRPmod1 delete plan-1 CD2 0.020
+TRPmod1 delete plan-1 CE2 0.020
+TRPmod1 delete plan-1 CE3 0.020
+TRPmod1 delete plan-1 CG 0.020
+TRPmod1 delete plan-1 CH2 0.020
+TRPmod1 delete plan-1 CZ2 0.020
+TRPmod1 delete plan-1 CZ3 0.020
+TRPmod1 delete plan-1 HE3 0.020
+TRPmod1 delete plan-1 HH2 0.020
+TRPmod1 delete plan-1 HZ2 0.020
+TRPmod1 delete plan-1 HZ3 0.020
+TRPmod1 delete plan-1 NE1 0.020
+
+data_mod_TYRmod4
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+TYRmod4 delete HE2 . H H 0
+TYRmod4 change CE2 . C CR6 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+TYRmod4 delete CE2 HE2 single . . . .
+TYRmod4 change CG CD2 single 1.391 0.0149 1.391 0.0149
+TYRmod4 change CD2 CE2 double 1.396 0.0127 1.396 0.0127
+TYRmod4 change CE2 CZ single 1.400 0.0131 1.400 0.0131
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+TYRmod4 delete CD2 CE2 HE2 . .
+TYRmod4 delete CZ CE2 HE2 . .
+TYRmod4 change CB CG CD2 121.325 2.28
+TYRmod4 change CD1 CG CD2 117.170 2.83
+TYRmod4 change CG CD2 CE2 123.240 3.00
+TYRmod4 change CD2 CE2 CZ 118.013 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+TYRmod4 delete plan-1 CB 0.020
+TYRmod4 delete plan-1 CD1 0.020
+TYRmod4 delete plan-1 CD2 0.020
+TYRmod4 delete plan-1 CE1 0.020
+TYRmod4 delete plan-1 CE2 0.020
+TYRmod4 delete plan-1 CG 0.020
+TYRmod4 delete plan-1 CZ 0.020
+TYRmod4 delete plan-1 HD1 0.020
+TYRmod4 delete plan-1 HD2 0.020
+TYRmod4 delete plan-1 HE1 0.020
+TYRmod4 delete plan-1 HE2 0.020
+TYRmod4 delete plan-1 OH 0.020
+
+data_mod_TYRmod5
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+TYRmod5 delete HH . H H 0
+TYRmod5 change OH . O O 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+TYRmod5 delete OH HH single . . . .
+TYRmod5 change CZ OH single 1.410 0.0100 1.410 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+TYRmod5 delete CZ OH HH . .
+TYRmod5 change CE1 CZ CE2 121.469 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+TYRmod5 delete CE1 CZ OH HH . . . 0
+
+data_mod_NH2mod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+NH2mod1 delete HN2 . H H .
+NH2mod1 change N . N NH2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+NH2mod1 delete HN2 N single . . . .
+NH2mod1 change N HN1 single 0.914 0.010 1.036 0.016
+NH2mod1 change N HN single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+NH2mod1 delete HN N HN2 . .
+NH2mod1 delete HN2 N HN1 . .
+NH2mod1 change HN1 N HN 120.093 2.38
+
+data_mod_CR8mod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+CR8mod2 delete H2 . H H 0
+CR8mod2 change N3 . N NR5 0
+CR8mod2 change N22 . N NR15 0
+CR8mod2 change N1 . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+CR8mod2 delete N1 H2 single . . . .
+CR8mod2 change N1 CA1 single 1.461 0.0100 1.461 0.0100
+CR8mod2 change N1 H single 0.875 0.0200 1.016 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+CR8mod2 delete CA1 N1 H2 . .
+CR8mod2 delete H N1 H2 . .
+CR8mod2 change CA1 N1 H 118.864 2.43
+CR8mod2 change C1 CA1 N1 108.143 2.92
+CR8mod2 change C20 CA1 N1 110.260 1.65
+
+data_mod_CROmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+CROmod2 delete H . H H 0
+CROmod2 change N1 . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+CROmod2 delete N1 H single . . . .
+CROmod2 change N1 CA1 single 1.461 0.0105 1.461 0.0105
+CROmod2 change N1 H2 single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+CROmod2 delete CA1 N1 H . .
+CROmod2 delete H N1 H2 . .
+CROmod2 change CA1 N1 H2 119.005 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+CROmod2 delete CB1 CA1 N1 H . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+CROmod2 delete plan-7 CA2 0.020
+CROmod2 delete plan-7 CB2 0.020
+CROmod2 delete plan-7 CG2 0.020
+CROmod2 delete plan-7 HB2 0.020
+CROmod2 delete plan-1 CB2 0.020
+CROmod2 delete plan-1 CD1 0.020
+CROmod2 delete plan-1 CD2 0.020
+CROmod2 delete plan-1 CE1 0.020
+CROmod2 delete plan-1 CE2 0.020
+CROmod2 delete plan-1 CG2 0.020
+CROmod2 delete plan-1 CZ 0.020
+CROmod2 delete plan-1 HD1 0.020
+CROmod2 delete plan-1 HD2 0.020
+CROmod2 delete plan-1 HE1 0.020
+CROmod2 delete plan-1 HE2 0.020
+CROmod2 delete plan-1 OH 0.020
+
+data_mod_GYCmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+GYCmod2 delete H2 . H H 0
+GYCmod2 change N1 . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+GYCmod2 delete N1 H2 single . . . .
+GYCmod2 change N1 CA1 single 1.461 0.0105 1.461 0.0105
+GYCmod2 change N1 H single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+GYCmod2 delete CA1 N1 H2 . .
+GYCmod2 delete H N1 H2 . .
+GYCmod2 change CA1 N1 H 119.005 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+GYCmod2 delete plan-5 CA2 0.020
+GYCmod2 delete plan-5 CB2 0.020
+GYCmod2 delete plan-5 CG2 0.020
+GYCmod2 delete plan-5 HB2 0.020
+GYCmod2 delete plan-1 CB2 0.020
+GYCmod2 delete plan-1 CD1 0.020
+GYCmod2 delete plan-1 CD2 0.020
+GYCmod2 delete plan-1 CE1 0.020
+GYCmod2 delete plan-1 CE2 0.020
+GYCmod2 delete plan-1 CG2 0.020
+GYCmod2 delete plan-1 CZ 0.020
+GYCmod2 delete plan-1 HD1 0.020
+GYCmod2 delete plan-1 HD2 0.020
+GYCmod2 delete plan-1 HE1 0.020
+GYCmod2 delete plan-1 HE2 0.020
+GYCmod2 delete plan-1 OH 0.020
+
+data_mod_NRQmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+NRQmod2 delete H . H H 0
+NRQmod2 change N1 . N N 0
+NRQmod2 change N3 . N NT 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+NRQmod2 delete N1 H single . . . .
+NRQmod2 change N1 CA1 double 1.287 0.0100 1.287 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+NRQmod2 delete CA1 N1 H . .
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+NRQmod2 delete CB1 CA1 N1 H . .
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+NRQmod2 delete plan-4 CA2 0.020
+NRQmod2 delete plan-4 CB2 0.020
+NRQmod2 delete plan-4 CG2 0.020
+NRQmod2 delete plan-4 HB2 0.020
+NRQmod2 delete plan-1 CB2 0.020
+NRQmod2 delete plan-1 CD1 0.020
+NRQmod2 delete plan-1 CD2 0.020
+NRQmod2 delete plan-1 CE1 0.020
+NRQmod2 delete plan-1 CE2 0.020
+NRQmod2 delete plan-1 CG2 0.020
+NRQmod2 delete plan-1 CZ 0.020
+NRQmod2 delete plan-1 HD1 0.020
+NRQmod2 delete plan-1 HD2 0.020
+NRQmod2 delete plan-1 HE1 0.020
+NRQmod2 delete plan-1 HE2 0.020
+NRQmod2 delete plan-1 OH 0.020
+
+data_mod_LYSmod5
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+LYSmod5 delete HZ2 . H H 0
+LYSmod5 delete HZ3 . H H 0
+LYSmod5 change NZ . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+LYSmod5 delete NZ HZ2 single . . . .
+LYSmod5 delete NZ HZ3 single . . . .
+LYSmod5 change CE NZ single 1.456 0.0109 1.456 0.0109
+LYSmod5 change NZ HZ1 single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+LYSmod5 delete CE NZ HZ2 . .
+LYSmod5 delete CE NZ HZ3 . .
+LYSmod5 delete HZ1 NZ HZ2 . .
+LYSmod5 delete HZ1 NZ HZ3 . .
+LYSmod5 delete HZ2 NZ HZ3 . .
+LYSmod5 change CE NZ HZ1 118.176 1.90
+
+data_mod_MDOmod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+MDOmod2 delete H2 . H H 0
+MDOmod2 change N1 . N NH1 0
+MDOmod2 change N3 . N NT 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+MDOmod2 delete N1 H2 single . . . .
+MDOmod2 change N1 CA1 single 1.461 0.0105 1.461 0.0105
+MDOmod2 change N1 H single 0.914 0.010 1.036 0.016
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+MDOmod2 delete CA1 N1 H2 . .
+MDOmod2 delete H N1 H2 . .
+MDOmod2 change CA1 N1 H 119.005 1.50
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+MDOmod2 delete plan-4 CA2 0.020
+MDOmod2 delete plan-4 CB2 0.020
+MDOmod2 delete plan-4 HB21 0.020
+MDOmod2 delete plan-4 HB22 0.020
+MDOmod2 delete plan-4 CA2 0.020
+MDOmod2 delete plan-4 CB2 0.020
+MDOmod2 delete plan-4 HB21 0.020
+MDOmod2 delete plan-4 HB22 0.020
+
+data_mod_MS6mod1
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+MS6mod1 delete H1 . H H 0
+MS6mod1 delete H3 . H H 0
+MS6mod1 delete H14 . H HSH1 0
+MS6mod1 change C . C C 0
+MS6mod1 change S . S S1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+MS6mod1 delete C H1 single . . . .
+MS6mod1 delete C H3 single . . . .
+MS6mod1 delete S H14 single . . . .
+MS6mod1 change C S double 1.666 0.0184 1.666 0.0184
+MS6mod1 change CA C single 1.524 0.0141 1.524 0.0141
+MS6mod1 change CA CB single 1.534 0.0101 1.534 0.0101
+MS6mod1 change CA HA single 0.985 0.0200 1.089 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+MS6mod1 delete CA C H1 . .
+MS6mod1 delete CA C H3 . .
+MS6mod1 delete S C H1 . .
+MS6mod1 delete S C H3 . .
+MS6mod1 delete H1 C H3 . .
+MS6mod1 delete C S H14 . .
+MS6mod1 change C CA CB 110.511 3.00
+MS6mod1 change C CA HA 107.928 2.09
+MS6mod1 change N CA HA 108.674 3.00
+MS6mod1 change S C CA 119.655 3.00
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+MS6mod1 delete CA C S H14 . . . 0
+MS6mod1 change S C CA CB sp2_sp3_1 0.000 10.0 6
+
+data_mod_MS6mod2
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+MS6mod2 delete H2 . H H 0
+MS6mod2 delete H3 . H H 0
+MS6mod2 change N . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+MS6mod2 delete N H2 single . . . .
+MS6mod2 delete N H3 single . . . .
+MS6mod2 change N CA single 1.454 0.0100 1.454 0.0100
+MS6mod2 change N H single 0.871 0.0200 1.016 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+MS6mod2 delete CA N H2 . .
+MS6mod2 delete CA N H3 . .
+MS6mod2 delete H N H2 . .
+MS6mod2 delete H N H3 . .
+MS6mod2 delete H2 N H3 . .
+MS6mod2 change CA N H 119.298 3.00
+MS6mod2 change N CA C 111.439 3.00
+
+data_mod_MS6delNH
+loop_
+_chem_mod_atom.mod_id
+_chem_mod_atom.function
+_chem_mod_atom.atom_id
+_chem_mod_atom.new_atom_id
+_chem_mod_atom.new_type_symbol
+_chem_mod_atom.new_type_energy
+_chem_mod_atom.new_charge
+MS6delNH delete H2 . H H 0
+MS6delNH change N . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+MS6delNH delete N H2 single . . . .
+MS6delNH change CA C single 1.518 0.0124 1.518 0.0124
+MS6delNH change CA HA single 1.011 0.0200 1.089 0.0100
+MS6delNH change N H single 0.860 0.0200 1.016 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+MS6delNH delete CA N H2 . .
+MS6delNH delete H N H2 . .
+MS6delNH change C CA CB 110.944 2.88
+MS6delNH change CB CA HA 107.855 2.00
+MS6delNH change CA N H 117.539 3.00


### PR DESCRIPTION
First step in splitting link descriptions out of list/mon_lib_list.cif. For now, the link description is just duplicated:

    sed -n '/^data_link_list/,$p' list/mon_lib_list.cif > links.cif

When we have major programs reading links.cif,
this part can be deleted from mon_lib_list.cif.

The goal is to make reading of links faster (in particular, that's important when reading from a web server). The size of links.cif is only 8% of mon_lib_list.cif (312406 vs 3990585 bytes).