### PR TITLE
Fix hydrides

### DIFF
--- a/d/D3O.cif
+++ b/d/D3O.cif
@@ -13,30 +13,40 @@ data_comp_D3O
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
 _chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-D3O O  O OH2 1 1.489 37.691 -2.079
-D3O D1 H H   0 1.558 37.731 -1.092
-D3O D2 H H   0 1.558 38.635 -2.371
-D3O D3 H H   0 2.341 37.279 -2.371
+D3O O  O  O O 1 1.511 37.691 -2.079
+D3O D1 D1 H H 0 2.440 37.691 -2.079
+D3O D2 D2 H H 0 1.047 38.496 -2.079
+D3O D3 D3 H H 0 1.047 36.886 -2.079
+
+loop_
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+D3O O  O(H)3
+D3O D1 H(OHH)
+D3O D2 H(OHH)
+D3O D3 H(OHH)
 
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
-_chem_comp_bond.type
-_chem_comp_bond.aromatic
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-D3O O D1 SINGLE n 0.970 0.0120 0.929 0.0200
-D3O O D2 SINGLE n 0.970 0.0120 0.929 0.0200
-D3O O D3 SINGLE n 0.970 0.0120 0.929 0.0200
+D3O O D1 SINGLE n 0.972 0.0180 0.929 0.0200
+D3O O D2 SINGLE n 0.972 0.0180 0.929 0.0200
+D3O O D3 SINGLE n 0.972 0.0180 0.929 0.0200
 
 loop_
 _chem_comp_angle.comp_id
@@ -48,3 +58,27 @@ _chem_comp_angle.value_angle_esd
 D3O D1 O D2 112.905 3.00
 D3O D1 O D3 112.905 3.00
 D3O D2 O D3 112.905 3.00
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+D3O SMILES           ACDLabs              12.01 "[2H][O+]([2H])[2H]"
+D3O InChI            InChI                1.03  InChI=1S/H2O/h1H2/p+1/i/hD3
+D3O InChIKey         InChI                1.03  XLYOFNOQVPJJNP-ZRLBSURWSA-O
+D3O SMILES_CANONICAL CACTVS               3.385 "[O+]([2H])([2H])[2H]"
+D3O SMILES           CACTVS               3.385 "[O+]([2H])([2H])[2H]"
+D3O SMILES_CANONICAL "OpenEye OEToolkits" 1.9.2 "[2H][O+]([2H])[2H]"
+D3O SMILES           "OpenEye OEToolkits" 1.9.2 "[2H][O+]([2H])[2H]"
+
+loop_
+_acedrg_chem_comp_descriptor.comp_id
+_acedrg_chem_comp_descriptor.program_name
+_acedrg_chem_comp_descriptor.program_version
+_acedrg_chem_comp_descriptor.type
+D3O acedrg          285       "dictionary generator"
+D3O acedrg_database 12        "data source"
+D3O rdkit           2019.09.1 "Chemoinformatics tool"
+D3O servalcat       0.4.57    'optimization tool'

--- a/h/H2S.cif
+++ b/h/H2S.cif
@@ -7,43 +7,43 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-H2S H2S 'HYDROSULFURIC ACID                  ' NON-POLYMER 3 1 .
+H2S H2S "HYDROSULFURIC ACID" NON-POLYMER 3 1 .
 
 data_comp_H2S
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
-_chem_comp_atom.partial_charge
+_chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-H2S HS2 H H 0.000 0.000 0.000 0.000
-H2S S S S2 0.000 -1.260 0.000 -0.469
-H2S HS1 H H 0.000 -1.018 0.000 -1.791
+H2S S   S   S SH1  0 27.069 73.238 42.929
+H2S HS1 HS1 H HSH1 0 28.282 73.238 42.929
+H2S HS2 HS2 H HSH1 0 26.864 74.434 42.929
 
 loop_
-_chem_comp_tree.comp_id
-_chem_comp_tree.atom_id
-_chem_comp_tree.atom_back
-_chem_comp_tree.atom_forward
-_chem_comp_tree.connect_type
-H2S HS2 n/a S START
-H2S S HS2 HS1 .
-H2S HS1 S . END
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+H2S S   S(H)2
+H2S HS1 H(SH)
+H2S HS2 H(SH)
 
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
-_chem_comp_bond.type
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-H2S HS1 S single 1.338 0.010 1.171 0.208
-H2S S HS2 single 1.338 0.010 1.171 0.208
+H2S S HS1 SINGLE n 1.338 0.0100 1.213 0.0200
+H2S S HS2 SINGLE n 1.338 0.0100 1.213 0.0200
 
 loop_
 _chem_comp_angle.comp_id
@@ -52,4 +52,27 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-H2S HS2 S HS1 100.018 3.000
+H2S HS1 S HS2 99.729 3.00
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+H2S SMILES_CANONICAL CACTVS               3.341 S
+H2S SMILES           CACTVS               3.341 S
+H2S SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0 S
+H2S SMILES           "OpenEye OEToolkits" 1.5.0 S
+H2S InChI            InChI                1.03  InChI=1S/H2S/h1H2
+H2S InChIKey         InChI                1.03  RWSOTUBLDIXVET-UHFFFAOYSA-N
+
+loop_
+_acedrg_chem_comp_descriptor.comp_id
+_acedrg_chem_comp_descriptor.program_name
+_acedrg_chem_comp_descriptor.program_version
+_acedrg_chem_comp_descriptor.type
+H2S acedrg          285       "dictionary generator"
+H2S acedrg_database 12        "data source"
+H2S rdkit           2019.09.1 "Chemoinformatics tool"
+H2S servalcat       0.4.57    'optimization tool'

--- a/h/HOH.cif
+++ b/h/HOH.cif
@@ -7,43 +7,43 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-HOH HOH 'WATER                               ' NON-POLYMER 3 1 .
+HOH HOH WATER NON-POLYMER 3 1 .
 
 data_comp_HOH
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
-_chem_comp_atom.partial_charge
+_chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-HOH H2 H H 0.000 0.000 0.000 0.000
-HOH O O OH2 0.000 -0.867 0.000 -0.427
-HOH H1 H H 0.000 -0.709 0.000 -1.381
+HOH O  O  O OH2 0 -23.107 18.382 -21.639
+HOH H1 H1 H H   0 -22.244 18.382 -21.639
+HOH H2 H2 H H   0 -23.365 19.206 -21.639
 
 loop_
-_chem_comp_tree.comp_id
-_chem_comp_tree.atom_id
-_chem_comp_tree.atom_back
-_chem_comp_tree.atom_forward
-_chem_comp_tree.connect_type
-HOH H2 n/a O START
-HOH O H2 H1 .
-HOH H1 O . END
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+HOH O  O(H)2
+HOH H1 H(OH)
+HOH H2 H(OH)
 
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
-_chem_comp_bond.type
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-HOH H1 O single 0.970 0.012 0.839 0.014
-HOH O H2 single 0.970 0.012 0.839 0.014
+HOH O H1 SINGLE n 0.972 0.0180 0.863 0.0200
+HOH O H2 SINGLE n 0.972 0.0180 0.863 0.0200
 
 loop_
 _chem_comp_angle.comp_id
@@ -52,4 +52,28 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-HOH H2 O H1 120.000 3.000
+HOH H1 O H2 107.391 3.00
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+HOH SMILES           ACDLabs              10.04 O
+HOH SMILES_CANONICAL CACTVS               3.341 O
+HOH SMILES           CACTVS               3.341 O
+HOH SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0 O
+HOH SMILES           "OpenEye OEToolkits" 1.5.0 O
+HOH InChI            InChI                1.03  InChI=1S/H2O/h1H2
+HOH InChIKey         InChI                1.03  XLYOFNOQVPJJNP-UHFFFAOYSA-N
+
+loop_
+_acedrg_chem_comp_descriptor.comp_id
+_acedrg_chem_comp_descriptor.program_name
+_acedrg_chem_comp_descriptor.program_version
+_acedrg_chem_comp_descriptor.type
+HOH acedrg          285       "dictionary generator"
+HOH acedrg_database 12        "data source"
+HOH rdkit           2019.09.1 "Chemoinformatics tool"
+HOH servalcat       0.4.57    'optimization tool'

--- a/links_and_mods.cif
+++ b/links_and_mods.cif
@@ -5305,7 +5305,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pep-NH2 1 C 2 N SINGLE 1.317 0.0154
+pep-NH2 1 C 2 N SINGLE 1.324 0.0120
 
 loop_
 _chem_link_angle.link_id
@@ -5317,10 +5317,26 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pep-NH2 1 CA 1 C 2 N 116.444 3.00
-pep-NH2 1 O 1 C 2 N 123.225 1.50
-pep-NH2 1 C 2 N 2 HN1 114.198 3.00
-pep-NH2 1 C 2 N 2 HN2 114.198 3.00
+pep-NH2 1 CA 1 C 2 N 116.005 1.50
+pep-NH2 1 O 1 C 2 N 123.568 1.50
+pep-NH2 1 C 2 N 2 HN1 119.943 3.00
+pep-NH2 1 C 2 N 2 HN2 119.943 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pep-NH2 sp2_sp2_1 1 CA 1 C 2 N 2 HN1 180.000 5.0 2
 
 loop_
 _chem_link_plane.link_id
@@ -5332,6 +5348,10 @@ pep-NH2 plan-1 1 CA 0.020
 pep-NH2 plan-1 1 C 0.020
 pep-NH2 plan-1 2 N 0.020
 pep-NH2 plan-1 1 O 0.020
+pep-NH2 plan-2 1 C 0.020
+pep-NH2 plan-2 2 HN1 0.020
+pep-NH2 plan-2 2 HN2 0.020
+pep-NH2 plan-2 2 N 0.020
 
 data_link_pept-CR8
 loop_
@@ -11387,7 +11407,7 @@ _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
 _chem_mod_atom.new_charge
 NH2mod1 delete H . H H 0
-NH2mod1 change N . N N32 0
+NH2mod1 change N . N NH2 0
 
 loop_
 _chem_mod_bond.mod_id
@@ -11400,8 +11420,6 @@ _chem_mod_bond.new_value_dist_esd
 _chem_mod_bond.new_value_dist_nucleus
 _chem_mod_bond.new_value_dist_nucleus_esd
 NH2mod1 delete N H single . . . .
-NH2mod1 change N HN1 single 0.922 0.0200 1.013 0.0120
-NH2mod1 change N HN2 single 0.922 0.0200 1.013 0.0120
 
 loop_
 _chem_mod_angle.mod_id
@@ -11413,6 +11431,7 @@ _chem_mod_angle.new_value_angle
 _chem_mod_angle.new_value_angle_esd
 NH2mod1 delete HN1 N H . .
 NH2mod1 delete HN2 N H . .
+NH2mod1 change HN1 N HN2 120.114 3.00
 
 data_mod_CR8mod2
 loop_

--- a/links_and_mods.cif
+++ b/links_and_mods.cif
@@ -5305,7 +5305,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pep-NH2 1 C 2 N SINGLE 1.324 0.0100
+pep-NH2 1 C 2 N SINGLE 1.317 0.0154
 
 loop_
 _chem_link_angle.link_id
@@ -5317,26 +5317,10 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pep-NH2 1 CA 1 C 2 N 114.873 1.50
-pep-NH2 1 O 1 C 2 N 123.611 1.50
-pep-NH2 1 C 2 N 2 HN1 119.954 1.50
-pep-NH2 1 C 2 N 2 HN 119.954 1.50
-
-loop_
-_chem_link_tor.link_id
-_chem_link_tor.id
-_chem_link_tor.atom_1_comp_id
-_chem_link_tor.atom_id_1
-_chem_link_tor.atom_2_comp_id
-_chem_link_tor.atom_id_2
-_chem_link_tor.atom_3_comp_id
-_chem_link_tor.atom_id_3
-_chem_link_tor.atom_4_comp_id
-_chem_link_tor.atom_id_4
-_chem_link_tor.value_angle
-_chem_link_tor.value_angle_esd
-_chem_link_tor.period
-pep-NH2 sp2_sp2_1 1 CA 1 C 2 N 2 HN1 180.000 5.00 2
+pep-NH2 1 CA 1 C 2 N 116.444 3.00
+pep-NH2 1 O 1 C 2 N 123.225 1.50
+pep-NH2 1 C 2 N 2 HN1 114.198 3.00
+pep-NH2 1 C 2 N 2 HN2 114.198 3.00
 
 loop_
 _chem_link_plane.link_id
@@ -5348,10 +5332,6 @@ pep-NH2 plan-1 1 CA 0.020
 pep-NH2 plan-1 1 C 0.020
 pep-NH2 plan-1 2 N 0.020
 pep-NH2 plan-1 1 O 0.020
-pep-NH2 plan-2 1 C 0.020
-pep-NH2 plan-2 2 HN 0.020
-pep-NH2 plan-2 2 HN1 0.020
-pep-NH2 plan-2 2 N 0.020
 
 data_link_pept-CR8
 loop_
@@ -11406,8 +11386,8 @@ _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
 _chem_mod_atom.new_charge
-NH2mod1 delete HN2 . H H .
-NH2mod1 change N . N NH2 0
+NH2mod1 delete H . H H 0
+NH2mod1 change N . N N32 0
 
 loop_
 _chem_mod_bond.mod_id
@@ -11419,9 +11399,9 @@ _chem_mod_bond.new_value_dist
 _chem_mod_bond.new_value_dist_esd
 _chem_mod_bond.new_value_dist_nucleus
 _chem_mod_bond.new_value_dist_nucleus_esd
-NH2mod1 delete HN2 N single . . . .
-NH2mod1 change N HN1 single 0.914 0.010 1.036 0.016
-NH2mod1 change N HN single 0.914 0.010 1.036 0.016
+NH2mod1 delete N H single . . . .
+NH2mod1 change N HN1 single 0.922 0.0200 1.013 0.0120
+NH2mod1 change N HN2 single 0.922 0.0200 1.013 0.0120
 
 loop_
 _chem_mod_angle.mod_id
@@ -11431,9 +11411,8 @@ _chem_mod_angle.atom_id_2
 _chem_mod_angle.atom_id_3
 _chem_mod_angle.new_value_angle
 _chem_mod_angle.new_value_angle_esd
-NH2mod1 delete HN N HN2 . .
-NH2mod1 delete HN2 N HN1 . .
-NH2mod1 change HN1 N HN 120.093 2.38
+NH2mod1 delete HN1 N H . .
+NH2mod1 delete HN2 N H . .
 
 data_mod_CR8mod2
 loop_

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -41205,7 +41205,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pep-NH2 1 C 2 N SINGLE 1.317 0.0154
+pep-NH2 1 C 2 N SINGLE 1.324 0.0120
 
 loop_
 _chem_link_angle.link_id
@@ -41217,10 +41217,26 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pep-NH2 1 CA 1 C 2 N 116.444 3.00
-pep-NH2 1 O 1 C 2 N 123.225 1.50
-pep-NH2 1 C 2 N 2 HN1 114.198 3.00
-pep-NH2 1 C 2 N 2 HN2 114.198 3.00
+pep-NH2 1 CA 1 C 2 N 116.005 1.50
+pep-NH2 1 O 1 C 2 N 123.568 1.50
+pep-NH2 1 C 2 N 2 HN1 119.943 3.00
+pep-NH2 1 C 2 N 2 HN2 119.943 3.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pep-NH2 sp2_sp2_1 1 CA 1 C 2 N 2 HN1 180.000 5.0 2
 
 loop_
 _chem_link_plane.link_id
@@ -41232,6 +41248,10 @@ pep-NH2 plan-1 1 CA 0.020
 pep-NH2 plan-1 1 C 0.020
 pep-NH2 plan-1 2 N 0.020
 pep-NH2 plan-1 1 O 0.020
+pep-NH2 plan-2 1 C 0.020
+pep-NH2 plan-2 2 HN1 0.020
+pep-NH2 plan-2 2 HN2 0.020
+pep-NH2 plan-2 2 N 0.020
 
 data_link_pept-CR8
 loop_
@@ -47287,7 +47307,7 @@ _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
 _chem_mod_atom.new_charge
 NH2mod1 delete H . H H 0
-NH2mod1 change N . N N32 0
+NH2mod1 change N . N NH2 0
 
 loop_
 _chem_mod_bond.mod_id
@@ -47300,8 +47320,6 @@ _chem_mod_bond.new_value_dist_esd
 _chem_mod_bond.new_value_dist_nucleus
 _chem_mod_bond.new_value_dist_nucleus_esd
 NH2mod1 delete N H single . . . .
-NH2mod1 change N HN1 single 0.922 0.0200 1.013 0.0120
-NH2mod1 change N HN2 single 0.922 0.0200 1.013 0.0120
 
 loop_
 _chem_mod_angle.mod_id
@@ -47313,6 +47331,7 @@ _chem_mod_angle.new_value_angle
 _chem_mod_angle.new_value_angle_esd
 NH2mod1 delete HN1 N H . .
 NH2mod1 delete HN2 N H . .
+NH2mod1 change HN1 N HN2 120.114 3.00
 
 data_mod_CR8mod2
 loop_

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -41205,7 +41205,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pep-NH2 1 C 2 N SINGLE 1.324 0.0100
+pep-NH2 1 C 2 N SINGLE 1.317 0.0154
 
 loop_
 _chem_link_angle.link_id
@@ -41217,26 +41217,10 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pep-NH2 1 CA 1 C 2 N 114.873 1.50
-pep-NH2 1 O 1 C 2 N 123.611 1.50
-pep-NH2 1 C 2 N 2 HN1 119.954 1.50
-pep-NH2 1 C 2 N 2 HN 119.954 1.50
-
-loop_
-_chem_link_tor.link_id
-_chem_link_tor.id
-_chem_link_tor.atom_1_comp_id
-_chem_link_tor.atom_id_1
-_chem_link_tor.atom_2_comp_id
-_chem_link_tor.atom_id_2
-_chem_link_tor.atom_3_comp_id
-_chem_link_tor.atom_id_3
-_chem_link_tor.atom_4_comp_id
-_chem_link_tor.atom_id_4
-_chem_link_tor.value_angle
-_chem_link_tor.value_angle_esd
-_chem_link_tor.period
-pep-NH2 sp2_sp2_1 1 CA 1 C 2 N 2 HN1 180.000 5.00 2
+pep-NH2 1 CA 1 C 2 N 116.444 3.00
+pep-NH2 1 O 1 C 2 N 123.225 1.50
+pep-NH2 1 C 2 N 2 HN1 114.198 3.00
+pep-NH2 1 C 2 N 2 HN2 114.198 3.00
 
 loop_
 _chem_link_plane.link_id
@@ -41248,10 +41232,6 @@ pep-NH2 plan-1 1 CA 0.020
 pep-NH2 plan-1 1 C 0.020
 pep-NH2 plan-1 2 N 0.020
 pep-NH2 plan-1 1 O 0.020
-pep-NH2 plan-2 1 C 0.020
-pep-NH2 plan-2 2 HN 0.020
-pep-NH2 plan-2 2 HN1 0.020
-pep-NH2 plan-2 2 N 0.020
 
 data_link_pept-CR8
 loop_
@@ -47306,8 +47286,8 @@ _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
 _chem_mod_atom.new_charge
-NH2mod1 delete HN2 . H H .
-NH2mod1 change N . N NH2 0
+NH2mod1 delete H . H H 0
+NH2mod1 change N . N N32 0
 
 loop_
 _chem_mod_bond.mod_id
@@ -47319,9 +47299,9 @@ _chem_mod_bond.new_value_dist
 _chem_mod_bond.new_value_dist_esd
 _chem_mod_bond.new_value_dist_nucleus
 _chem_mod_bond.new_value_dist_nucleus_esd
-NH2mod1 delete HN2 N single . . . .
-NH2mod1 change N HN1 single 0.914 0.010 1.036 0.016
-NH2mod1 change N HN single 0.914 0.010 1.036 0.016
+NH2mod1 delete N H single . . . .
+NH2mod1 change N HN1 single 0.922 0.0200 1.013 0.0120
+NH2mod1 change N HN2 single 0.922 0.0200 1.013 0.0120
 
 loop_
 _chem_mod_angle.mod_id
@@ -47331,9 +47311,8 @@ _chem_mod_angle.atom_id_2
 _chem_mod_angle.atom_id_3
 _chem_mod_angle.new_value_angle
 _chem_mod_angle.new_value_angle_esd
-NH2mod1 delete HN N HN2 . .
-NH2mod1 delete HN2 N HN1 . .
-NH2mod1 change HN1 N HN 120.093 2.38
+NH2mod1 delete HN1 N H . .
+NH2mod1 delete HN2 N H . .
 
 data_mod_CR8mod2
 loop_

--- a/n/NH2.cif
+++ b/n/NH2.cif
@@ -7,46 +7,46 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-NH2 NH2 'AMINO GROUP                         ' NON-POLYMER 4 1 .
+NH2 NH2 "AMINO GROUP" NON-POLYMER 4 1 .
 
 data_comp_NH2
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
-_chem_comp_atom.partial_charge
+_chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-NH2 HN H H 0.000 0.000 0.000 0.000
-NH2 N N N 0.000 0.674 0.674 0.000
-NH2 HN2 H H 0.000 1.595 0.427 0.000
-NH2 HN1 H H 0.000 0.427 1.595 0.000
+NH2 N   N   N N33 0 10.097 8.960 -7.822
+NH2 HN1 HN1 H H   0 10.995 8.960 -7.822
+NH2 HN2 HN2 H H   0 9.648  9.738 -7.822
+NH2 H   H   H H   0 9.648  8.182 -7.822
 
 loop_
-_chem_comp_tree.comp_id
-_chem_comp_tree.atom_id
-_chem_comp_tree.atom_back
-_chem_comp_tree.atom_forward
-_chem_comp_tree.connect_type
-NH2 HN n/a N START
-NH2 N HN HN1 .
-NH2 HN2 N . .
-NH2 HN1 N . END
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+NH2 N   N(H)3
+NH2 HN1 H(NHH)
+NH2 HN2 H(NHH)
+NH2 H   H(NHH)
 
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
-_chem_comp_bond.type
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-NH2 HN1 N single 1.036 0.016 0.954 0.020
-NH2 HN2 N single 1.036 0.016 0.954 0.020
-NH2 N HN single 1.036 0.016 0.954 0.020
+NH2 N HN1 SINGLE n 1.018 0.0520 0.898 0.0200
+NH2 N HN2 SINGLE n 1.018 0.0520 0.898 0.0200
+NH2 N H   SINGLE n 1.018 0.0520 0.898 0.0200
 
 loop_
 _chem_comp_angle.comp_id
@@ -55,6 +55,30 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-NH2 HN N HN2 120.000 3.000
-NH2 HN N HN1 120.000 3.000
-NH2 HN2 N HN1 120.000 3.000
+NH2 HN1 N HN2 107.512 3.00
+NH2 HN1 N H   107.512 3.00
+NH2 HN2 N H   107.512 3.00
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+NH2 SMILES           ACDLabs              10.04 N
+NH2 InChI            InChI                1.06  InChI=1S/H3N/h1H3
+NH2 InChIKey         InChI                1.06  QGZKDVFQNNGYKY-UHFFFAOYSA-N
+NH2 SMILES_CANONICAL CACTVS               3.385 "[NH2]"
+NH2 SMILES           CACTVS               3.385 "[NH2]"
+NH2 SMILES_CANONICAL "OpenEye OEToolkits" 2.0.7 "[NH2]"
+NH2 SMILES           "OpenEye OEToolkits" 2.0.7 "[NH2]"
+
+loop_
+_acedrg_chem_comp_descriptor.comp_id
+_acedrg_chem_comp_descriptor.program_name
+_acedrg_chem_comp_descriptor.program_version
+_acedrg_chem_comp_descriptor.type
+NH2 acedrg          285       "dictionary generator"
+NH2 acedrg_database 12        "data source"
+NH2 rdkit           2019.09.1 "Chemoinformatics tool"
+NH2 servalcat       0.4.57    'optimization tool'

--- a/n/NH3.cif
+++ b/n/NH3.cif
@@ -7,46 +7,46 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-NH3 NH3 'AMMONIA                             ' NON-POLYMER 4 1 .
+NH3 NH3 AMMONIA NON-POLYMER 4 1 .
 
 data_comp_NH3
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
-_chem_comp_atom.partial_charge
+_chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-NH3 HN3 H H 0.000 0.000 0.000 0.000
-NH3 N N N 0.000 -0.180 0.886 0.447
-NH3 HN2 H H 0.000 0.372 1.574 -0.040
-NH3 HN1 H H 0.000 0.194 0.821 1.381
+NH3 N   N   N N33 0 52.010 -12.715 -42.848
+NH3 HN1 HN1 H H   0 52.908 -12.715 -42.848
+NH3 HN2 HN2 H H   0 51.561 -11.937 -42.848
+NH3 HN3 HN3 H H   0 51.561 -13.493 -42.848
 
 loop_
-_chem_comp_tree.comp_id
-_chem_comp_tree.atom_id
-_chem_comp_tree.atom_back
-_chem_comp_tree.atom_forward
-_chem_comp_tree.connect_type
-NH3 HN3 n/a N START
-NH3 N HN3 HN1 .
-NH3 HN2 N . .
-NH3 HN1 N . END
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+NH3 N   N(H)3
+NH3 HN1 H(NHH)
+NH3 HN2 H(NHH)
+NH3 HN3 H(NHH)
 
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
-_chem_comp_bond.type
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-NH3 HN1 N single 1.036 0.016 0.954 0.020
-NH3 HN2 N single 1.036 0.016 0.954 0.020
-NH3 N HN3 single 1.036 0.016 0.954 0.020
+NH3 N HN1 SINGLE n 1.018 0.0520 0.898 0.0200
+NH3 N HN2 SINGLE n 1.018 0.0520 0.898 0.0200
+NH3 N HN3 SINGLE n 1.018 0.0520 0.898 0.0200
 
 loop_
 _chem_comp_angle.comp_id
@@ -55,6 +55,30 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-NH3 HN3 N HN2 120.000 3.000
-NH3 HN3 N HN1 120.000 3.000
-NH3 HN2 N HN1 120.000 3.000
+NH3 HN1 N HN2 107.512 3.00
+NH3 HN1 N HN3 107.512 3.00
+NH3 HN2 N HN3 107.512 3.00
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+NH3 SMILES           ACDLabs              10.04 N
+NH3 SMILES_CANONICAL CACTVS               3.341 N
+NH3 SMILES           CACTVS               3.341 N
+NH3 SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0 N
+NH3 SMILES           "OpenEye OEToolkits" 1.5.0 N
+NH3 InChI            InChI                1.03  InChI=1S/H3N/h1H3
+NH3 InChIKey         InChI                1.03  QGZKDVFQNNGYKY-UHFFFAOYSA-N
+
+loop_
+_acedrg_chem_comp_descriptor.comp_id
+_acedrg_chem_comp_descriptor.program_name
+_acedrg_chem_comp_descriptor.program_version
+_acedrg_chem_comp_descriptor.type
+NH3 acedrg          285       "dictionary generator"
+NH3 acedrg_database 12        "data source"
+NH3 rdkit           2019.09.1 "Chemoinformatics tool"
+NH3 servalcat       0.4.57    'optimization tool'

--- a/n/NH4.cif
+++ b/n/NH4.cif
@@ -7,49 +7,49 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-NH4 NH4 'AMMONIUM ION                        ' NON-POLYMER 5 1 .
+NH4 NH4 "AMMONIUM ION" NON-POLYMER 5 1 .
 
 data_comp_NH4
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
-_chem_comp_atom.partial_charge
+_chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-NH4 HN4 H H 0.000 0.000 0.000 0.000
-NH4 N N NT 1.000 -0.581 0.302 -0.782
-NH4 HN3 H H 0.000 -1.232 1.041 -0.516
-NH4 HN2 H H 0.000 -0.024 0.609 -1.579
-NH4 HN1 H H 0.000 -1.055 -0.583 -0.962
+NH4 N   N   N NT4 1 11.106 19.172 34.702
+NH4 HN1 HN1 H H   0 12.007 19.171 34.702
+NH4 HN2 HN2 H H   0 10.807 20.021 34.702
+NH4 HN3 HN3 H H   0 10.806 18.747 35.438
+NH4 HN4 HN4 H H   0 10.806 18.747 33.966
 
 loop_
-_chem_comp_tree.comp_id
-_chem_comp_tree.atom_id
-_chem_comp_tree.atom_back
-_chem_comp_tree.atom_forward
-_chem_comp_tree.connect_type
-NH4 N . HN1 START
-NH4 HN4 N . .
-NH4 HN3 N . .
-NH4 HN2 N . .
-NH4 HN1 N . END
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+NH4 N   N(H)4
+NH4 HN1 H(NH3)
+NH4 HN2 H(NH3)
+NH4 HN3 H(NH3)
+NH4 HN4 H(NH3)
 
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
-_chem_comp_bond.type
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-NH4 HN1 N single 1.036 0.016 0.914 0.007
-NH4 HN2 N single 1.036 0.016 0.914 0.007
-NH4 HN3 N single 1.036 0.016 0.914 0.007
-NH4 N HN4 single 1.036 0.016 0.914 0.007
+NH4 N HN1 SINGLE n 1.018 0.0520 0.901 0.0200
+NH4 N HN2 SINGLE n 1.018 0.0520 0.901 0.0200
+NH4 N HN3 SINGLE n 1.018 0.0520 0.901 0.0200
+NH4 N HN4 SINGLE n 1.018 0.0520 0.901 0.0200
 
 loop_
 _chem_comp_angle.comp_id
@@ -58,9 +58,33 @@ _chem_comp_angle.atom_id_2
 _chem_comp_angle.atom_id_3
 _chem_comp_angle.value_angle
 _chem_comp_angle.value_angle_esd
-NH4 HN4 N HN3 109.500 3.000
-NH4 HN4 N HN2 109.500 3.000
-NH4 HN4 N HN1 109.500 3.000
-NH4 HN3 N HN2 109.500 3.000
-NH4 HN3 N HN1 109.500 3.000
-NH4 HN2 N HN1 109.500 3.000
+NH4 HN1 N HN2 109.370 3.00
+NH4 HN1 N HN3 109.370 3.00
+NH4 HN1 N HN4 109.370 3.00
+NH4 HN2 N HN3 109.370 3.00
+NH4 HN2 N HN4 109.370 3.00
+NH4 HN3 N HN4 109.370 3.00
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+NH4 SMILES           ACDLabs              10.04 "[NH4+]"
+NH4 SMILES_CANONICAL CACTVS               3.341 "[NH4+]"
+NH4 SMILES           CACTVS               3.341 "[NH4+]"
+NH4 SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0 "[NH4+]"
+NH4 SMILES           "OpenEye OEToolkits" 1.5.0 "[NH4+]"
+NH4 InChI            InChI                1.03  InChI=1S/H3N/h1H3/p+1
+NH4 InChIKey         InChI                1.03  QGZKDVFQNNGYKY-UHFFFAOYSA-O
+
+loop_
+_acedrg_chem_comp_descriptor.comp_id
+_acedrg_chem_comp_descriptor.program_name
+_acedrg_chem_comp_descriptor.program_version
+_acedrg_chem_comp_descriptor.type
+NH4 acedrg          285       "dictionary generator"
+NH4 acedrg_database 12        "data source"
+NH4 rdkit           2019.09.1 "Chemoinformatics tool"
+NH4 servalcat       0.4.57    'optimization tool'

--- a/o/OH.cif
+++ b/o/OH.cif
@@ -7,37 +7,61 @@ _chem_comp.group
 _chem_comp.number_atoms_all
 _chem_comp.number_atoms_nh
 _chem_comp.desc_level
-OH OH 'HYDROXIDE ION                       ' NON-POLYMER 2 1 .
+OH OH "HYDROXIDE ION" NON-POLYMER 2 1 .
 
 data_comp_OH
 loop_
 _chem_comp_atom.comp_id
 _chem_comp_atom.atom_id
+_chem_comp_atom.alt_atom_id
 _chem_comp_atom.type_symbol
 _chem_comp_atom.type_energy
-_chem_comp_atom.partial_charge
+_chem_comp_atom.charge
 _chem_comp_atom.x
 _chem_comp_atom.y
 _chem_comp_atom.z
-OH HO H H 0.000 0.000 0.000 0.000
-OH O O O -1.000 -0.650 0.000 -0.715
+OH O  O  O OC -1 14.860 37.830 7.076
+OH HO HO H H  0  15.874 37.830 7.076
 
 loop_
-_chem_comp_tree.comp_id
-_chem_comp_tree.atom_id
-_chem_comp_tree.atom_back
-_chem_comp_tree.atom_forward
-_chem_comp_tree.connect_type
-OH HO n/a O START
-OH O HO . END
+_chem_comp_acedrg.comp_id
+_chem_comp_acedrg.atom_id
+_chem_comp_acedrg.atom_type
+OH O  O(H)
+OH HO H(O)
 
 loop_
 _chem_comp_bond.comp_id
 _chem_comp_bond.atom_id_1
 _chem_comp_bond.atom_id_2
-_chem_comp_bond.type
+_chem_comp_bond.value_order
+_chem_comp_bond.pdbx_aromatic_flag
 _chem_comp_bond.value_dist_nucleus
 _chem_comp_bond.value_dist_nucleus_esd
 _chem_comp_bond.value_dist
 _chem_comp_bond.value_dist_esd
-OH O HO single 1.040 0.020 1.040 0.020
+OH O HO SINGLE n 0.966 0.0059 1.014 0.0200
+
+loop_
+_pdbx_chem_comp_descriptor.comp_id
+_pdbx_chem_comp_descriptor.type
+_pdbx_chem_comp_descriptor.program
+_pdbx_chem_comp_descriptor.program_version
+_pdbx_chem_comp_descriptor.descriptor
+OH SMILES           ACDLabs              10.04 "[OH-]"
+OH SMILES_CANONICAL CACTVS               3.341 "[OH-]"
+OH SMILES           CACTVS               3.341 "[OH-]"
+OH SMILES_CANONICAL "OpenEye OEToolkits" 1.5.0 "[OH-]"
+OH SMILES           "OpenEye OEToolkits" 1.5.0 "[OH-]"
+OH InChI            InChI                1.03  InChI=1S/H2O/h1H2/p-1
+OH InChIKey         InChI                1.03  XLYOFNOQVPJJNP-UHFFFAOYSA-M
+
+loop_
+_acedrg_chem_comp_descriptor.comp_id
+_acedrg_chem_comp_descriptor.program_name
+_acedrg_chem_comp_descriptor.program_version
+_acedrg_chem_comp_descriptor.type
+OH acedrg          285       "dictionary generator"
+OH acedrg_database 12        "data source"
+OH rdkit           2019.09.1 "Chemoinformatics tool"
+OH servalcat       0.4.57    'optimization tool'


### PR DESCRIPTION
XH<sub>n</sub> entries have not been updated (although some of them were wrong), since Acedrg could not handle them. Now it's possible, and they were regenerated using Acedrg 285. Some angles may need further corrections. Links should be updated also.

for the pep-NH2 link:
```
LINK: RES-NAME-1 ALA ATOM-NAME-1 C RES-NAME-2 NH2 ATOM-NAME-2 N DELETE ATOM OXT 1 DELETE ATOM H 2
```