### PR TITLE
Fix pyr-SER and pyr-THR

### DIFF
--- a/links_and_mods.cif
+++ b/links_and_mods.cif
@@ -2319,7 +2319,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pyr-SER 1 C1 2 OG single 1.439 .020
+pyr-SER 1 C1 2 OG SINGLE 1.404 0.0151
 
 loop_
 _chem_link_angle.link_id
@@ -2331,8 +2331,27 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pyr-SER 1 C1 2 OG 2 CB 108.700 3.000
-pyr-SER 1 O5 1 C1 2 OG 112.300 3.000
+pyr-SER 1 C2 1 C1 2 OG 108.438 1.50
+pyr-SER 1 O5 1 C1 2 OG 109.874 3.00
+pyr-SER 2 OG 1 C1 1 H1 109.395 1.50
+pyr-SER 2 CB 2 OG 1 C1 113.917 2.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pyr-SER sp3_sp3_1 1 C2 1 C1 2 OG 2 CB 180.000 10.0 3
+pyr-SER sp3_sp3_2 2 CA 2 CB 2 OG 1 C1 180.000 10.0 3
 
 loop_
 _chem_link_chir.link_id
@@ -2345,7 +2364,7 @@ _chem_link_chir.atom_id_2
 _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
-pyr-SER 1 C1 2 OG 1 O5 1 C2 positiv
+pyr-SER 1 C1 2 OG 1 O5 1 C2 both
 
 data_link_pyr-THR
 loop_
@@ -2357,7 +2376,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pyr-THR 1 C1 2 OG1 single 1.439 .020
+pyr-THR 1 C1 2 OG1 SINGLE 1.391 0.0100
 
 loop_
 _chem_link_angle.link_id
@@ -2369,8 +2388,27 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pyr-THR 1 C1 2 OG1 2 CB 108.700 3.000
-pyr-THR 1 O5 1 C1 2 OG1 112.300 3.000
+pyr-THR 1 C2 1 C1 2 OG1 108.438 1.50
+pyr-THR 1 O5 1 C1 2 OG1 109.874 3.00
+pyr-THR 2 OG1 1 C1 1 H1 109.395 1.50
+pyr-THR 2 CB 2 OG1 1 C1 115.156 2.22
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pyr-THR sp3_sp3_1 1 C2 1 C1 2 OG1 2 CB 180.000 10.0 3
+pyr-THR sp3_sp3_2 2 CA 2 CB 2 OG1 1 C1 180.000 10.0 3
 
 loop_
 _chem_link_chir.link_id
@@ -2383,7 +2421,7 @@ _chem_link_chir.atom_id_2
 _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
-pyr-THR 1 C1 2 OG1 1 O5 1 C2 positiv
+pyr-THR 1 C1 1 O5 2 OG1 1 C2 both
 
 data_link_pyr-ASN
 loop_
@@ -2395,7 +2433,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pyr-ASN 1 C1 2 ND2 single 1.439 .020
+pyr-ASN 1 C1 2 ND2 SINGLE 1.432 0.0100
 
 loop_
 _chem_link_angle.link_id
@@ -2407,23 +2445,31 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pyr-ASN 1 C1 2 ND2 2 CG 121.000 3.000
-pyr-ASN 1 C1 2 ND2 2 HD21 119.000 3.000
-pyr-ASN 1 O5 1 C1 2 ND2 112.300 3.000
-pyr-ASN 1 C2 1 C1 2 ND2 112.700 3.000
+pyr-ASN 1 C2 1 C1 2 ND2 110.887 3.00
+pyr-ASN 1 O5 1 C1 2 ND2 108.933 3.00
+pyr-ASN 2 ND2 1 C1 1 H1 108.874 1.50
+pyr-ASN 2 CG 2 ND2 1 C1 122.596 1.50
+pyr-ASN 1 C1 2 ND2 2 HD21 118.683 3.00
 
 loop_
-_chem_link_plane.link_id
-_chem_link_plane.plane_id
-_chem_link_plane.atom_comp_id
-_chem_link_plane.atom_id
-_chem_link_plane.dist_esd
-pyr-ASN plane1 1 C1 .020
-pyr-ASN plane1 2 ND2 .020
-pyr-ASN plane1 2 CG .020
-pyr-ASN plane1 2 OD1 .020
-pyr-ASN plane1 2 CB .020
-pyr-ASN plane1 2 HD21 .020
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pyr-ASN sp2_sp3_1 2 CG 2 ND2 1 C1 1 C2 0.000 20.0 6
+pyr-ASN sp2_sp2_1 2 CB 2 CG 2 ND2 1 C1 180.000 5.0 2
+pyr-ASN sp3_sp3_2 2 ND2 1 C1 1 C2 1 N2 180.000 10.0 3
+pyr-ASN sp3_sp3_2 2 ND2 1 C1 1 C2 1 N2 180.000 10.0 3
+pyr-ASN sp3_sp3_3 2 ND2 1 C1 1 O5 1 C5 60.000 10.0 3
 
 loop_
 _chem_link_chir.link_id
@@ -2436,7 +2482,18 @@ _chem_link_chir.atom_id_2
 _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
-pyr-ASN 1 C1 2 ND2 1 O5 1 C2 positiv
+pyr-ASN 1 C1 1 O5 2 ND2 1 C2 negative
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pyr-ASN plan-5 1 C1 0.020
+pyr-ASN plan-5 2 CG 0.020
+pyr-ASN plan-5 2 HD21 0.020
+pyr-ASN plan-5 2 ND2 0.020
 
 data_link_ZN-CYS
 loop_
@@ -8602,8 +8659,61 @@ _chem_mod_atom.atom_id
 _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-DEL-HD22 delete HD22 . . . .000
+_chem_mod_atom.new_charge
+DEL-HD22 delete HD22 . H H 0
+DEL-HD22 change ND2 . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HD22 delete ND2 HD22 single . . . .
+DEL-HD22 change CB CG single 1.520 0.0174 1.520 0.0174
+DEL-HD22 change CG OD1 double 1.227 0.0138 1.227 0.0138
+DEL-HD22 change ND2 HD21 single 0.863 0.0200 1.013 0.0120
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HD22 delete CG ND2 HD22 . .
+DEL-HD22 delete HD21 ND2 HD22 . .
+DEL-HD22 change CA CB CG 112.357 3.00
+DEL-HD22 change OD1 CG ND2 123.445 2.69
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+DEL-HD22 delete CB CG ND2 HD22 . . . 2
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+DEL-HD22 delete plan-3 CG 0.020
+DEL-HD22 delete plan-3 HD21 0.020
+DEL-HD22 delete plan-3 HD22 0.020
+DEL-HD22 delete plan-3 ND2 0.020
 
 data_mod_DEL-HG
 loop_
@@ -8613,8 +8723,53 @@ _chem_mod_atom.atom_id
 _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-DEL-HG delete HG . . . .000
+_chem_mod_atom.new_charge
+DEL-HG delete HG . H H 0
+DEL-HG change OG . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HG delete OG HG single . . . .
+DEL-HG change CA CB single 1.518 0.0126 1.518 0.0126
+DEL-HG change CB OG single 1.426 0.0176 1.426 0.0176
+DEL-HG change CB HB3 single 0.982 0.0125 1.092 0.0100
+DEL-HG change CB HB2 single 0.982 0.0125 1.092 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HG delete CB OG HG . .
+DEL-HG change N CA CB 113.399 3.00
+DEL-HG change C CA CB 111.339 3.00
+DEL-HG change CA CB OG 109.581 3.00
+DEL-HG change OG CB HB3 109.634 2.46
+DEL-HG change OG CB HB2 109.634 2.46
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+DEL-HG delete CA CB OG HG . . . 3
 
 data_mod_DEL-HG1
 loop_
@@ -8624,8 +8779,53 @@ _chem_mod_atom.atom_id
 _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-DEL-HG1 delete HG1 . . . .000
+_chem_mod_atom.new_charge
+DEL-HG1 delete HG1 . H H 0
+DEL-HG1 change OG1 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HG1 delete OG1 HG1 single . . . .
+DEL-HG1 change CA CB single 1.538 0.0100 1.538 0.0100
+DEL-HG1 change CB OG1 single 1.440 0.0100 1.440 0.0100
+DEL-HG1 change CB CG2 single 1.508 0.0200 1.508 0.0200
+DEL-HG1 change CB HB single 0.993 0.0134 1.092 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HG1 delete CB OG1 HG1 . .
+DEL-HG1 change N CA CB 113.399 3.00
+DEL-HG1 change C CA CB 111.339 3.00
+DEL-HG1 change CA CB OG1 111.145 1.50
+DEL-HG1 change CA CB CG2 110.837 3.00
+DEL-HG1 change CG2 CB HB 109.492 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+DEL-HG1 delete CA CB OG1 HG1 . . . 3
 
 data_mod_ACYmod
 loop_

--- a/links_and_mods.cif
+++ b/links_and_mods.cif
@@ -2467,8 +2467,6 @@ _chem_link_tor.value_angle_esd
 _chem_link_tor.period
 pyr-ASN sp2_sp3_1 2 CG 2 ND2 1 C1 1 C2 0.000 20.0 6
 pyr-ASN sp2_sp2_1 2 CB 2 CG 2 ND2 1 C1 180.000 5.0 2
-pyr-ASN sp3_sp3_2 2 ND2 1 C1 1 C2 1 N2 180.000 10.0 3
-pyr-ASN sp3_sp3_2 2 ND2 1 C1 1 C2 1 N2 180.000 10.0 3
 pyr-ASN sp3_sp3_3 2 ND2 1 C1 1 O5 1 C5 60.000 10.0 3
 
 loop_

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -38219,7 +38219,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pyr-SER 1 C1 2 OG single 1.439 .020
+pyr-SER 1 C1 2 OG SINGLE 1.404 0.0151
 
 loop_
 _chem_link_angle.link_id
@@ -38231,8 +38231,27 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pyr-SER 1 C1 2 OG 2 CB 108.700 3.000
-pyr-SER 1 O5 1 C1 2 OG 112.300 3.000
+pyr-SER 1 C2 1 C1 2 OG 108.438 1.50
+pyr-SER 1 O5 1 C1 2 OG 109.874 3.00
+pyr-SER 2 OG 1 C1 1 H1 109.395 1.50
+pyr-SER 2 CB 2 OG 1 C1 113.917 2.00
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pyr-SER sp3_sp3_1 1 C2 1 C1 2 OG 2 CB 180.000 10.0 3
+pyr-SER sp3_sp3_2 2 CA 2 CB 2 OG 1 C1 180.000 10.0 3
 
 loop_
 _chem_link_chir.link_id
@@ -38245,7 +38264,7 @@ _chem_link_chir.atom_id_2
 _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
-pyr-SER 1 C1 2 OG 1 O5 1 C2 positiv
+pyr-SER 1 C1 2 OG 1 O5 1 C2 both
 
 data_link_pyr-THR
 loop_
@@ -38257,7 +38276,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pyr-THR 1 C1 2 OG1 single 1.439 .020
+pyr-THR 1 C1 2 OG1 SINGLE 1.391 0.0100
 
 loop_
 _chem_link_angle.link_id
@@ -38269,8 +38288,27 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pyr-THR 1 C1 2 OG1 2 CB 108.700 3.000
-pyr-THR 1 O5 1 C1 2 OG1 112.300 3.000
+pyr-THR 1 C2 1 C1 2 OG1 108.438 1.50
+pyr-THR 1 O5 1 C1 2 OG1 109.874 3.00
+pyr-THR 2 OG1 1 C1 1 H1 109.395 1.50
+pyr-THR 2 CB 2 OG1 1 C1 115.156 2.22
+
+loop_
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pyr-THR sp3_sp3_1 1 C2 1 C1 2 OG1 2 CB 180.000 10.0 3
+pyr-THR sp3_sp3_2 2 CA 2 CB 2 OG1 1 C1 180.000 10.0 3
 
 loop_
 _chem_link_chir.link_id
@@ -38283,7 +38321,7 @@ _chem_link_chir.atom_id_2
 _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
-pyr-THR 1 C1 2 OG1 1 O5 1 C2 positiv
+pyr-THR 1 C1 1 O5 2 OG1 1 C2 both
 
 data_link_pyr-ASN
 loop_
@@ -38295,7 +38333,7 @@ _chem_link_bond.atom_id_2
 _chem_link_bond.type
 _chem_link_bond.value_dist
 _chem_link_bond.value_dist_esd
-pyr-ASN 1 C1 2 ND2 single 1.439 .020
+pyr-ASN 1 C1 2 ND2 SINGLE 1.432 0.0100
 
 loop_
 _chem_link_angle.link_id
@@ -38307,23 +38345,31 @@ _chem_link_angle.atom_3_comp_id
 _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
-pyr-ASN 1 C1 2 ND2 2 CG 121.000 3.000
-pyr-ASN 1 C1 2 ND2 2 HD21 119.000 3.000
-pyr-ASN 1 O5 1 C1 2 ND2 112.300 3.000
-pyr-ASN 1 C2 1 C1 2 ND2 112.700 3.000
+pyr-ASN 1 C2 1 C1 2 ND2 110.887 3.00
+pyr-ASN 1 O5 1 C1 2 ND2 108.933 3.00
+pyr-ASN 2 ND2 1 C1 1 H1 108.874 1.50
+pyr-ASN 2 CG 2 ND2 1 C1 122.596 1.50
+pyr-ASN 1 C1 2 ND2 2 HD21 118.683 3.00
 
 loop_
-_chem_link_plane.link_id
-_chem_link_plane.plane_id
-_chem_link_plane.atom_comp_id
-_chem_link_plane.atom_id
-_chem_link_plane.dist_esd
-pyr-ASN plane1 1 C1 .020
-pyr-ASN plane1 2 ND2 .020
-pyr-ASN plane1 2 CG .020
-pyr-ASN plane1 2 OD1 .020
-pyr-ASN plane1 2 CB .020
-pyr-ASN plane1 2 HD21 .020
+_chem_link_tor.link_id
+_chem_link_tor.id
+_chem_link_tor.atom_1_comp_id
+_chem_link_tor.atom_id_1
+_chem_link_tor.atom_2_comp_id
+_chem_link_tor.atom_id_2
+_chem_link_tor.atom_3_comp_id
+_chem_link_tor.atom_id_3
+_chem_link_tor.atom_4_comp_id
+_chem_link_tor.atom_id_4
+_chem_link_tor.value_angle
+_chem_link_tor.value_angle_esd
+_chem_link_tor.period
+pyr-ASN sp2_sp3_1 2 CG 2 ND2 1 C1 1 C2 0.000 20.0 6
+pyr-ASN sp2_sp2_1 2 CB 2 CG 2 ND2 1 C1 180.000 5.0 2
+pyr-ASN sp3_sp3_2 2 ND2 1 C1 1 C2 1 N2 180.000 10.0 3
+pyr-ASN sp3_sp3_2 2 ND2 1 C1 1 C2 1 N2 180.000 10.0 3
+pyr-ASN sp3_sp3_3 2 ND2 1 C1 1 O5 1 C5 60.000 10.0 3
 
 loop_
 _chem_link_chir.link_id
@@ -38336,7 +38382,18 @@ _chem_link_chir.atom_id_2
 _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
-pyr-ASN 1 C1 2 ND2 1 O5 1 C2 positiv
+pyr-ASN 1 C1 1 O5 2 ND2 1 C2 negative
+
+loop_
+_chem_link_plane.link_id
+_chem_link_plane.plane_id
+_chem_link_plane.atom_comp_id
+_chem_link_plane.atom_id
+_chem_link_plane.dist_esd
+pyr-ASN plan-5 1 C1 0.020
+pyr-ASN plan-5 2 CG 0.020
+pyr-ASN plan-5 2 HD21 0.020
+pyr-ASN plan-5 2 ND2 0.020
 
 data_link_ZN-CYS
 loop_
@@ -44502,8 +44559,61 @@ _chem_mod_atom.atom_id
 _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-DEL-HD22 delete HD22 . . . .000
+_chem_mod_atom.new_charge
+DEL-HD22 delete HD22 . H H 0
+DEL-HD22 change ND2 . N NH1 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HD22 delete ND2 HD22 single . . . .
+DEL-HD22 change CB CG single 1.520 0.0174 1.520 0.0174
+DEL-HD22 change CG OD1 double 1.227 0.0138 1.227 0.0138
+DEL-HD22 change ND2 HD21 single 0.863 0.0200 1.013 0.0120
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HD22 delete CG ND2 HD22 . .
+DEL-HD22 delete HD21 ND2 HD22 . .
+DEL-HD22 change CA CB CG 112.357 3.00
+DEL-HD22 change OD1 CG ND2 123.445 2.69
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+DEL-HD22 delete CB CG ND2 HD22 . . . 2
+
+loop_
+_chem_mod_plane_atom.mod_id
+_chem_mod_plane_atom.function
+_chem_mod_plane_atom.plane_id
+_chem_mod_plane_atom.atom_id
+_chem_mod_plane_atom.new_dist_esd
+DEL-HD22 delete plan-3 CG 0.020
+DEL-HD22 delete plan-3 HD21 0.020
+DEL-HD22 delete plan-3 HD22 0.020
+DEL-HD22 delete plan-3 ND2 0.020
 
 data_mod_DEL-HG
 loop_
@@ -44513,8 +44623,53 @@ _chem_mod_atom.atom_id
 _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-DEL-HG delete HG . . . .000
+_chem_mod_atom.new_charge
+DEL-HG delete HG . H H 0
+DEL-HG change OG . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HG delete OG HG single . . . .
+DEL-HG change CA CB single 1.518 0.0126 1.518 0.0126
+DEL-HG change CB OG single 1.426 0.0176 1.426 0.0176
+DEL-HG change CB HB3 single 0.982 0.0125 1.092 0.0100
+DEL-HG change CB HB2 single 0.982 0.0125 1.092 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HG delete CB OG HG . .
+DEL-HG change N CA CB 113.399 3.00
+DEL-HG change C CA CB 111.339 3.00
+DEL-HG change CA CB OG 109.581 3.00
+DEL-HG change OG CB HB3 109.634 2.46
+DEL-HG change OG CB HB2 109.634 2.46
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+DEL-HG delete CA CB OG HG . . . 3
 
 data_mod_DEL-HG1
 loop_
@@ -44524,8 +44679,53 @@ _chem_mod_atom.atom_id
 _chem_mod_atom.new_atom_id
 _chem_mod_atom.new_type_symbol
 _chem_mod_atom.new_type_energy
-_chem_mod_atom.new_partial_charge
-DEL-HG1 delete HG1 . . . .000
+_chem_mod_atom.new_charge
+DEL-HG1 delete HG1 . H H 0
+DEL-HG1 change OG1 . O O2 0
+
+loop_
+_chem_mod_bond.mod_id
+_chem_mod_bond.function
+_chem_mod_bond.atom_id_1
+_chem_mod_bond.atom_id_2
+_chem_mod_bond.new_type
+_chem_mod_bond.new_value_dist
+_chem_mod_bond.new_value_dist_esd
+_chem_mod_bond.new_value_dist_nucleus
+_chem_mod_bond.new_value_dist_nucleus_esd
+DEL-HG1 delete OG1 HG1 single . . . .
+DEL-HG1 change CA CB single 1.538 0.0100 1.538 0.0100
+DEL-HG1 change CB OG1 single 1.440 0.0100 1.440 0.0100
+DEL-HG1 change CB CG2 single 1.508 0.0200 1.508 0.0200
+DEL-HG1 change CB HB single 0.993 0.0134 1.092 0.0100
+
+loop_
+_chem_mod_angle.mod_id
+_chem_mod_angle.function
+_chem_mod_angle.atom_id_1
+_chem_mod_angle.atom_id_2
+_chem_mod_angle.atom_id_3
+_chem_mod_angle.new_value_angle
+_chem_mod_angle.new_value_angle_esd
+DEL-HG1 delete CB OG1 HG1 . .
+DEL-HG1 change N CA CB 113.399 3.00
+DEL-HG1 change C CA CB 111.339 3.00
+DEL-HG1 change CA CB OG1 111.145 1.50
+DEL-HG1 change CA CB CG2 110.837 3.00
+DEL-HG1 change CG2 CB HB 109.492 1.50
+
+loop_
+_chem_mod_tor.mod_id
+_chem_mod_tor.function
+_chem_mod_tor.atom_id_1
+_chem_mod_tor.atom_id_2
+_chem_mod_tor.atom_id_3
+_chem_mod_tor.atom_id_4
+_chem_mod_tor.id
+_chem_mod_tor.new_value_angle
+_chem_mod_tor.new_value_angle_esd
+_chem_mod_tor.new_period
+DEL-HG1 delete CA CB OG1 HG1 . . . 3
 
 data_mod_ACYmod
 loop_

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -38367,8 +38367,6 @@ _chem_link_tor.value_angle_esd
 _chem_link_tor.period
 pyr-ASN sp2_sp3_1 2 CG 2 ND2 1 C1 1 C2 0.000 20.0 6
 pyr-ASN sp2_sp2_1 2 CB 2 CG 2 ND2 1 C1 180.000 5.0 2
-pyr-ASN sp3_sp3_2 2 ND2 1 C1 1 C2 1 N2 180.000 10.0 3
-pyr-ASN sp3_sp3_2 2 ND2 1 C1 1 C2 1 N2 180.000 10.0 3
 pyr-ASN sp3_sp3_3 2 ND2 1 C1 1 O5 1 C5 60.000 10.0 3
 
 loop_


### PR DESCRIPTION
Some angle restraints were missing in pyr-SER and pyr-THR, which could easily lead to distorted geometry. I have updated pyr-ASN, pyr-SER, and pyr-THR updated using acedrg 294.

To support several O-linked glycosylations I have changed chirals in pyr-SER and pyr-THR to "both" (thanks @glycojones - correct me if I'm wrong). We may need more specific links for O-linked glycosylations. By the way I suppose chiral restraints have not been used for these links, because of missing angles.

```
LINK: RES-NAME-1 NAG ATOM-NAME-1 C1 RES-NAME-2 ASN ATOM-NAME-2 ND2 DELETE ATOM O1 1 FILE-1 acedrg_NAG.cif FILE-2 acedrg_ASN.cif
```
```
LINK: RES-NAME-1 NAG ATOM-NAME-1 C1 RES-NAME-2 SER ATOM-NAME-2 OG DELETE ATOM O1 1 FILE-1 acedrg_NAG.cif FILE-2 acedrg_SER.cif
```
```
LINK: RES-NAME-1 NAG ATOM-NAME-1 C1 RES-NAME-2 THR ATOM-NAME-2 OG1 DELETE ATOM O1 1 FILE-1 acedrg_NAG.cif FILE-2 acedrg_THR.cif
```