### PR TITLE
delete SS link

### DIFF
--- a/links_and_mods.cif
+++ b/links_and_mods.cif
@@ -11,7 +11,6 @@ _chem_link.name
 DG9-SER DG9 DG9m1 NON-POLYMER SER SERm1 peptide DG9-SER
 DNA-SER . DEL_OP3 DNA/RNA SER SERm1 peptide DNA-SER
 DNA-TYR . DEL_OP3 DNA/RNA TYR TYRmod5 peptide DNA-TYR
-SS . CYS-SS peptide . CYS-SS peptide SS-bridge
 disulf CYS CYS-SS peptide CYS CYS-SS peptide SS-bridge
 CYS-MPR CYS CYS-SS peptide MPR MPRm1 NON-POLYMER SS-bridge
 TRANS . DEL-OXT peptide . DEL-HN1 peptide TRANS
@@ -426,47 +425,6 @@ _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
 DNA-TYR 1 P 1 "O5'" 2 OH 1 OP2 both
-
-data_link_SS
-loop_
-_chem_link_bond.link_id
-_chem_link_bond.atom_1_comp_id
-_chem_link_bond.atom_id_1
-_chem_link_bond.atom_2_comp_id
-_chem_link_bond.atom_id_2
-_chem_link_bond.type
-_chem_link_bond.value_dist
-_chem_link_bond.value_dist_esd
-SS 1 SG 2 SG single 2.031 .020
-
-loop_
-_chem_link_angle.link_id
-_chem_link_angle.atom_1_comp_id
-_chem_link_angle.atom_id_1
-_chem_link_angle.atom_2_comp_id
-_chem_link_angle.atom_id_2
-_chem_link_angle.atom_3_comp_id
-_chem_link_angle.atom_id_3
-_chem_link_angle.value_angle
-_chem_link_angle.value_angle_esd
-SS 1 CB 1 SG 2 SG 103.800 1.800
-SS 1 SG 2 SG 2 CB 103.800 1.800
-
-loop_
-_chem_link_tor.link_id
-_chem_link_tor.id
-_chem_link_tor.atom_1_comp_id
-_chem_link_tor.atom_id_1
-_chem_link_tor.atom_2_comp_id
-_chem_link_tor.atom_id_2
-_chem_link_tor.atom_3_comp_id
-_chem_link_tor.atom_id_3
-_chem_link_tor.atom_4_comp_id
-_chem_link_tor.atom_id_4
-_chem_link_tor.value_angle
-_chem_link_tor.value_angle_esd
-_chem_link_tor.period
-SS ss 1 CB 1 SG 2 SG 2 CB 90.00 10.0 2
 
 data_link_disulf
 loop_

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -36352,7 +36352,6 @@ _chem_link.name
 DG9-SER DG9 DG9m1 NON-POLYMER SER SERm1 peptide DG9-SER
 DNA-SER . DEL_OP3 DNA/RNA SER SERm1 peptide DNA-SER
 DNA-TYR . DEL_OP3 DNA/RNA TYR TYRmod5 peptide DNA-TYR
-SS . CYS-SS peptide . CYS-SS peptide SS-bridge
 disulf CYS CYS-SS peptide CYS CYS-SS peptide SS-bridge
 CYS-MPR CYS CYS-SS peptide MPR MPRm1 NON-POLYMER SS-bridge
 TRANS . DEL-OXT peptide . DEL-HN1 peptide TRANS
@@ -36767,47 +36766,6 @@ _chem_link_chir.atom_3_comp_id
 _chem_link_chir.atom_id_3
 _chem_link_chir.volume_sign
 DNA-TYR 1 P 1 "O5'" 2 OH 1 OP2 both
-
-data_link_SS
-loop_
-_chem_link_bond.link_id
-_chem_link_bond.atom_1_comp_id
-_chem_link_bond.atom_id_1
-_chem_link_bond.atom_2_comp_id
-_chem_link_bond.atom_id_2
-_chem_link_bond.type
-_chem_link_bond.value_dist
-_chem_link_bond.value_dist_esd
-SS 1 SG 2 SG single 2.031 .020
-
-loop_
-_chem_link_angle.link_id
-_chem_link_angle.atom_1_comp_id
-_chem_link_angle.atom_id_1
-_chem_link_angle.atom_2_comp_id
-_chem_link_angle.atom_id_2
-_chem_link_angle.atom_3_comp_id
-_chem_link_angle.atom_id_3
-_chem_link_angle.value_angle
-_chem_link_angle.value_angle_esd
-SS 1 CB 1 SG 2 SG 103.800 1.800
-SS 1 SG 2 SG 2 CB 103.800 1.800
-
-loop_
-_chem_link_tor.link_id
-_chem_link_tor.id
-_chem_link_tor.atom_1_comp_id
-_chem_link_tor.atom_id_1
-_chem_link_tor.atom_2_comp_id
-_chem_link_tor.atom_id_2
-_chem_link_tor.atom_3_comp_id
-_chem_link_tor.atom_id_3
-_chem_link_tor.atom_4_comp_id
-_chem_link_tor.atom_id_4
-_chem_link_tor.value_angle
-_chem_link_tor.value_angle_esd
-_chem_link_tor.period
-SS ss 1 CB 1 SG 2 SG 2 CB 90.00 10.0 2
 
 data_link_disulf
 loop_


### PR DESCRIPTION
In the monomer library, the link SS (not disulf) is defined for any peptide residues having the "SG" atom. This is dangerous, because accidental SS links can be made. 
```
SS . CYS-SS peptide . CYS-SS peptide SS-bridge
```
In the current library, there are 77 peptide monomers having SG atom, but only `03Y CG6 CYS DCY LE1 LEI` are SS-linkable (others have C-S-C bonds for example).

I checked the "disulfide" connections from mmcif headers of the pdb entries including these monomers (apart from CYS), and found the following patterns. The DCY-DCY link is already defined as "Ddisul".
```
('DCY', 'DCY') 40 pdb
('CYS', 'DCY') 5 pdb
('CYS', 'LE1') 3 pdb
```