### PR TITLE
p link: set phosphate bond angle sigmas to 1.5

### DIFF
--- a/links_and_mods.cif
+++ b/links_and_mods.cif
@@ -1016,9 +1016,9 @@ _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
 p 1 "C3'" 1 "O3'" 2 P 121.082 1.50
-p 2 OP1 2 P 1 "O3'" 109.493 3.00
-p 2 OP2 2 P 1 "O3'" 109.493 3.00
-p 2 "O5'" 2 P 1 "O3'" 100.661 3.00
+p 2 OP1 2 P 1 "O3'" 109.493 1.50
+p 2 OP2 2 P 1 "O3'" 109.493 1.50
+p 2 "O5'" 2 P 1 "O3'" 100.661 1.50
 
 loop_
 _chem_link_tor.link_id
@@ -6743,8 +6743,8 @@ DEL_OP3 delete OP3 P OP1 . .
 DEL_OP3 delete OP3 P OP2 . .
 DEL_OP3 delete OP3 P "O5'" . .
 DEL_OP3 change OP1 P OP2 118.304 1.50
-DEL_OP3 change OP1 P "O5'" 108.008 3.00
-DEL_OP3 change OP2 P "O5'" 108.008 3.00
+DEL_OP3 change OP1 P "O5'" 108.008 1.50
+DEL_OP3 change OP2 P "O5'" 108.008 1.50
 
 loop_
 _chem_mod_tor.mod_id

--- a/list/mon_lib_list.cif
+++ b/list/mon_lib_list.cif
@@ -37357,9 +37357,9 @@ _chem_link_angle.atom_id_3
 _chem_link_angle.value_angle
 _chem_link_angle.value_angle_esd
 p 1 "C3'" 1 "O3'" 2 P 121.082 1.50
-p 2 OP1 2 P 1 "O3'" 109.493 3.00
-p 2 OP2 2 P 1 "O3'" 109.493 3.00
-p 2 "O5'" 2 P 1 "O3'" 100.661 3.00
+p 2 OP1 2 P 1 "O3'" 109.493 1.50
+p 2 OP2 2 P 1 "O3'" 109.493 1.50
+p 2 "O5'" 2 P 1 "O3'" 100.661 1.50
 
 loop_
 _chem_link_tor.link_id
@@ -43084,8 +43084,8 @@ DEL_OP3 delete OP3 P OP1 . .
 DEL_OP3 delete OP3 P OP2 . .
 DEL_OP3 delete OP3 P "O5'" . .
 DEL_OP3 change OP1 P OP2 118.304 1.50
-DEL_OP3 change OP1 P "O5'" 108.008 3.00
-DEL_OP3 change OP2 P "O5'" 108.008 3.00
+DEL_OP3 change OP1 P "O5'" 108.008 1.50
+DEL_OP3 change OP2 P "O5'" 108.008 1.50
 
 loop_
 _chem_mod_tor.mod_id


### PR DESCRIPTION
Some of phosphate bond angle sigmas in the p link (the standard link for DNA/RNA) were set to 3.0 degrees (acedrg's default max) due to a lack of reference data. These large sigma values can lead to distorted geometry during refinement.